### PR TITLE
Remove unnecessary scoped binding for `RecordsBuffer`

### DIFF
--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -26,7 +26,6 @@ use Laravel\Nightwatch\Contracts\Clock as ClockContract;
 use Laravel\Nightwatch\Contracts\Ingest as IngestContract;
 use Laravel\Nightwatch\Contracts\PeakMemoryProvider;
 use Laravel\Nightwatch\Ingests\HttpIngest;
-use Laravel\Nightwatch\Ingests\NullIngest;
 use Laravel\Nightwatch\Ingests\SocketIngest;
 use Laravel\Nightwatch\Providers\PeakMemory;
 use React\EventLoop\StreamSelectLoop;


### PR DESCRIPTION
The scoped binding for `RecordsBuffer` is unnecessary since `SensorManager` manually instantiates it without using dependency injection.
https://github.com/laravel/nightwatch/blob/4eab6992dd88f4cddfb5ac2fa418f9e684b0711d/src/SensorManager.php#L66