### PR TITLE
Ensure outgoing response size and request size is not nullable

### DIFF
--- a/src/Records/OutgoingRequest.php
+++ b/src/Records/OutgoingRequest.php
@@ -30,8 +30,8 @@ final class OutgoingRequest
         public string $port,
         public string $path,
         public int $duration,
-        public ?int $request_size,
-        public ?int $response_size,
+        public int $request_size,
+        public int $response_size,
         public string $status_code,
     ) {
         //

--- a/src/Sensors/OutgoingRequestSensor.php
+++ b/src/Sensors/OutgoingRequestSensor.php
@@ -59,8 +59,8 @@ final class OutgoingRequestSensor
             port: $port,
             path: $request->getUri()->getPath(),
             duration: $duration,
-            request_size: $this->resolveMessageSize($request),
-            response_size: $this->resolveMessageSize($response),
+            request_size: $this->resolveMessageSize($request) ?? 0,
+            response_size: $this->resolveMessageSize($response) ?? 0,
             status_code: (string) $response->getStatusCode(),
         ));
     }


### PR DESCRIPTION
Our values are not nullable. We should fallback to `0`. I've created a ticket to capture these values in a better way in the future.