### PR TITLE
update changelog workflow to bypass branch protection

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -8,6 +8,86 @@ permissions: {}
 
 jobs:
   update:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    uses: laravel/.github/.github/workflows/update-changelog.yml@main
+
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.NIGHTWATCH_PERMISSIONS_APP_ID }}
+          private-key: ${{ secrets.NIGHTWATCH_PERMISSIONS_APP_PRIVATE_KEY }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Bypass branch protection
+          token: ${{ steps.app-token.outputs.token }}
+          # Fetch entire history of repository to ensure release date can be
+          # extracted from commit of the given tag.
+          fetch-depth: 0
+          # Checkout target branch of this release. Ensures that the CHANGELOG
+          # is not out of date.
+          ref: ${{ github.event.release.target_commitish }}
+
+      - name: Check if branch and release match
+        if: ${{ github.event.release.target_commitish != 'main' && github.event.release.target_commitish != 'master' }}
+        id: guard
+        run: |
+          NUMERIC_VERSION="${RELEASE_TAG_NAME#v}"
+          MAJOR_VERSION="${NUMERIC_VERSION%%.*}"
+          BRANCH_MAJOR_VERSION="${BRANCH%%.*}"
+
+          echo "MAJOR_VERSION=$(echo $MAJOR_VERSION)" >> $GITHUB_OUTPUT;
+          echo "BRANCH_MAJOR_VERSION=$(echo $BRANCH_MAJOR_VERSION)" >> $GITHUB_OUTPUT;
+
+          if [ "$MAJOR_VERSION" != "$BRANCH_MAJOR_VERSION" ]; then
+            echo "Mismatched versions! Aborting."
+            VERSION_MISMATCH='true';
+          else
+            echo "Versions match! Proceeding."
+            VERSION_MISMATCH='false';
+          fi
+          echo "VERSION_MISMATCH=$(echo $VERSION_MISMATCH)" >> $GITHUB_OUTPUT;
+        env:
+          BRANCH: ${{ github.event.release.target_commitish }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+
+      - name: Fail if branch and release tag do not match
+        if: ${{ steps.guard.outputs.VERSION_MISMATCH == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+              core.setFailed('Workflow failed. Release version does not match with selected target branch. Changelog not updated automatically.')
+
+      - name: Extract release date from git tag
+        id: release_date
+        run: |
+          # Get UNIX timestamp from git-tag
+          TIMESTAMP_OF_RELEASE_COMMIT=$(git log -1 --date=unix --format=%ad '${{ github.event.release.tag_name }}');
+
+          # Convert timestamp to UTC date in Y-m-d format
+          FORMATED_DATE=$(date -u -d @$TIMESTAMP_OF_RELEASE_COMMIT +%Y-%m-%d)
+
+          # Make date available to other steps
+          echo "date=$(echo $FORMATED_DATE)" >> $GITHUB_OUTPUT;
+
+      - name: Update Changelog
+        uses: stefanzweifel/changelog-updater-action@v1
+        with:
+          # Pass extracted release date, release notes and version to the Action.
+          release-date: ${{ steps.release_date.outputs.date }}
+          release-notes: ${{ github.event.release.body }}
+          latest-version: ${{ github.event.release.tag_name }}
+          compare-url-target-revision: ${{ github.event.release.target_commitish }}
+          parse-github-usernames: true
+
+      - name: Commit updated CHANGELOG
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          # Push updated CHANGELOG to release target branch.
+          branch: ${{ github.event.release.target_commitish }}
+          commit_message: Update CHANGELOG
+          file_pattern: CHANGELOG.md
+


### PR DESCRIPTION
Uses a token requested from the Nightwatch permissions app to interact with the repo