### PR TITLE
Migrate auth url from config to command option

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -2,10 +2,7 @@
 
 return [
     'enabled' => env('NIGHTWATCH_ENABLED', true),
-
     'token' => env('NIGHTWATCH_TOKEN'),
-    'auth_url' => env('NIGHTWATCH_AUTH_URL', 'https://nightwatch.laravel.com/api/agent-auth'),
-
     'deployment' => env('NIGHTWATCH_DEPLOY'),
     'server' => env('NIGHTWATCH_SERVER', (string) gethostname()),
 

--- a/src/Console/Agent.php
+++ b/src/Console/Agent.php
@@ -28,7 +28,7 @@ final class Agent extends Command
     /**
      * @var string
      */
-    protected $signature = 'nightwatch:agent';
+    protected $signature = 'nightwatch:agent {--base-url=}';
 
     /**
      * @var string

--- a/src/Factories/HttpIngestFactory.php
+++ b/src/Factories/HttpIngestFactory.php
@@ -18,7 +18,6 @@ final class HttpIngestFactory
      * @param  array{
      *      enabled?: bool,
      *      token?: string,
-     *      auth_url?: string,
      *      deployment?: string,
      *      server?: string,
      *      local_ingest?: string,

--- a/src/Factories/IngestDetailsRepositoryFactory.php
+++ b/src/Factories/IngestDetailsRepositoryFactory.php
@@ -16,7 +16,6 @@ final class IngestDetailsRepositoryFactory
      * @param  array{
      *      enabled?: bool,
      *      token?: string,
-     *      auth_url?: string,
      *      deployment?: string,
      *      server?: string,
      *      local_ingest?: string,
@@ -32,6 +31,7 @@ final class IngestDetailsRepositoryFactory
      */
     public function __construct(
         private array $config,
+        private string $base,
     ) {
         //
     }
@@ -47,7 +47,7 @@ final class IngestDetailsRepositoryFactory
             ->withHeader('authorization', "Bearer {$token}")
             ->withHeader('user-agent', 'NightwatchAgent/1')
             ->withHeader('content-type', 'application/json')
-            ->withBase($this->config['auth_url'] ?? '');
+            ->withBase("{$this->base}/api/agent-auth");
 
         return new IngestDetailsRepository($browser);
     }

--- a/src/Factories/LogIngestFactory.php
+++ b/src/Factories/LogIngestFactory.php
@@ -15,7 +15,6 @@ final class LogIngestFactory
      * @param  array{
      *      enabled?: bool,
      *      token?: string,
-     *      auth_url?: string,
      *      deployment?: string,
      *      server?: string,
      *      local_ingest?: string,

--- a/src/Factories/RemoteIngestFactory.php
+++ b/src/Factories/RemoteIngestFactory.php
@@ -16,7 +16,6 @@ final class RemoteIngestFactory
      * @param  array{
      *      enabled?: bool,
      *      token?: string,
-     *      auth_url?: string,
      *      deployment?: string,
      *      server?: string,
      *      local_ingest?: string,

--- a/src/Factories/SocketIngestFactory.php
+++ b/src/Factories/SocketIngestFactory.php
@@ -16,7 +16,6 @@ final class SocketIngestFactory
      * @param  array{
      *      enabled?: bool,
      *      token?: string,
-     *      auth_url?: string,
      *      deployment?: string,
      *      server?: string,
      *      local_ingest?: string,

--- a/src/Factories/SocketServerFactory.php
+++ b/src/Factories/SocketServerFactory.php
@@ -15,7 +15,6 @@ final class SocketServerFactory
      * @param  array{
      *      enabled?: bool,
      *      token?: string,
-     *      auth_url?: string,
      *      deployment?: string,
      *      server?: string,
      *      local_ingest?: string,

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -98,7 +98,6 @@ final class NightwatchServiceProvider extends ServiceProvider
      * @var array{
      *     enabled?: bool,
      *     token?: string,
-     *     auth_url?: string,
      *     deployment?: string,
      *     server?: string,
      *     local_ingest?: string,


### PR DESCRIPTION
We currently allow the auth url to be configured via the `.env`. This means that it is always present in the config file, even though only a handful of installs will ever have to touch this.

This PR moves the value from an environment / config option to an agent command option. That way, those few apps that have a custom auth url can configure the agent:

```
php artisan nightwatch:agent --base-url=https://another.env.nightwatch.com
```

I used the "base url" name as it felt a little nicer from a public API perspective to only have to reference the base.

We will need to manually update Forge and Nightwatch when they update to this version.