### PR TITLE
Capture notification duration

### DIFF
--- a/src/Hooks/NotificationListener.php
+++ b/src/Hooks/NotificationListener.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nightwatch\Hooks;
 
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
@@ -11,7 +12,7 @@ use Throwable;
 /**
  * @internal
  */
-final class NotificationSentListener
+final class NotificationListener
 {
     /**
      * @param  Core<RequestState|CommandState>  $nightwatch
@@ -22,7 +23,7 @@ final class NotificationSentListener
         //
     }
 
-    public function __invoke(NotificationSent $event): void
+    public function __invoke(NotificationSending|NotificationSent $event): void
     {
         try {
             $this->nightwatch->sensor->notification($event);

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -30,6 +30,7 @@ use Illuminate\Http\Client\Factory as Http;
 use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Log\LogManager;
 use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Routing\Events\PreparingResponse;
@@ -55,7 +56,7 @@ use Laravel\Nightwatch\Hooks\HttpKernelResolvedHandler;
 use Laravel\Nightwatch\Hooks\JobQueuedListener;
 use Laravel\Nightwatch\Hooks\LogoutListener;
 use Laravel\Nightwatch\Hooks\MessageSentListener;
-use Laravel\Nightwatch\Hooks\NotificationSentListener;
+use Laravel\Nightwatch\Hooks\NotificationListener;
 use Laravel\Nightwatch\Hooks\PreparingResponseListener;
 use Laravel\Nightwatch\Hooks\QueryExecutedListener;
 use Laravel\Nightwatch\Hooks\RequestBootedHandler;
@@ -267,7 +268,7 @@ final class NightwatchServiceProvider extends ServiceProvider
         /**
          * @see \Laravel\Nightwatch\Records\Notification
          */
-        $events->listen(NotificationSent::class, (new NotificationSentListener($core))(...));
+        $events->listen([NotificationSending::class, NotificationSent::class], (new NotificationListener($core))(...));
 
         /**
          * @see \Laravel\Nightwatch\Records\OutgoingRequest

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -10,6 +10,7 @@ use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Events\MessageSent;
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Events\JobAttempted;
 use Illuminate\Queue\Events\JobQueued;
@@ -138,7 +139,7 @@ class SensorManager
         $sensor($event);
     }
 
-    public function notification(NotificationSent $event): void
+    public function notification(NotificationSending|NotificationSent $event): void
     {
         $sensor = $this->notificationSensor ??= new NotificationSensor(
             executionState: $this->executionState,

--- a/src/Sensors/NotificationSensor.php
+++ b/src/Sensors/NotificationSensor.php
@@ -2,14 +2,17 @@
 
 namespace Laravel\Nightwatch\Sensors;
 
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Laravel\Nightwatch\Clock;
 use Laravel\Nightwatch\Records\Notification;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Laravel\Nightwatch\Types\Str;
+use RuntimeException;
 
 use function hash;
+use function round;
 use function str_contains;
 
 /**
@@ -17,6 +20,10 @@ use function str_contains;
  */
 final class NotificationSensor
 {
+    private ?float $startTime = null;
+
+    private ?int $duration = null;
+
     public function __construct(
         private RequestState|CommandState $executionState,
         private Clock $clock,
@@ -24,9 +31,20 @@ final class NotificationSensor
         //
     }
 
-    public function __invoke(NotificationSent $event): void
+    public function __invoke(NotificationSending|NotificationSent $event): void
     {
         $now = $this->clock->microtime();
+
+        if ($event instanceof NotificationSending) {
+            $this->startTime = $now;
+            $this->duration = null;
+
+            return;
+        }
+
+        if ($this->startTime === null) {
+            throw new RuntimeException('No start time found for ['.$event->notifiable::class.'].');
+        }
 
         if (str_contains($event->notification::class, "@anonymous\0")) {
             $class = Str::before($event->notification::class, "\0");
@@ -34,6 +52,7 @@ final class NotificationSensor
             $class = $event->notification::class;
         }
 
+        $this->duration ??= (int) round(($now - $this->startTime) * 1_000_000);
         $this->executionState->notifications++;
 
         $this->executionState->records->write(new Notification(
@@ -48,8 +67,8 @@ final class NotificationSensor
             user: $this->executionState->user->id(),
             channel: $event->channel,
             class: $class,
-            duration: 0, // TODO
-            failed: false, // TODO
+            duration: $this->duration,
+            failed: false, // TODO: The framework doesn't dispatch the `NotificationFailed` event.
         ));
     }
 }

--- a/src/Sensors/NotificationSensor.php
+++ b/src/Sensors/NotificationSensor.php
@@ -52,7 +52,7 @@ final class NotificationSensor
             $class = $event->notification::class;
         }
 
-        $this->duration ??= (int) round(($now - $this->startTime) * 1_000_000);
+        $this->duration = (int) round(($now - $this->startTime) * 1_000_000);
         $this->executionState->notifications++;
 
         $this->executionState->records->write(new Notification(

--- a/src/Sensors/NotificationSensor.php
+++ b/src/Sensors/NotificationSensor.php
@@ -43,7 +43,7 @@ final class NotificationSensor
         }
 
         if ($this->startTime === null) {
-            throw new RuntimeException('No start time found for ['.$event->notifiable::class.'].');
+            throw new RuntimeException('No start time found for ['.$event->notifiable::class.'].'); // @phpstan-ignore classConstant.nonObject
         }
 
         if (str_contains($event->notification::class, "@anonymous\0")) {

--- a/tests/Feature/Sensors/NotificationSensorTest.php
+++ b/tests/Feature/Sensors/NotificationSensorTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Illuminate\Support\Facades\Route;
 
 use function Pest\Laravel\post;
+use function Pest\Laravel\travelTo;
 
 beforeAll(function () {
     forceRequestExecutionState();
@@ -56,7 +57,7 @@ it('ingests on-demand notifications', function () {
         [
             'v' => 1,
             't' => 'notification',
-            'timestamp' => 946688523.456789,
+            'timestamp' => 946688523.459289,
             'deploy' => 'v1.2.3',
             'server' => 'web-01',
             '_group' => hash('md5', 'MyNotification'),
@@ -67,7 +68,7 @@ it('ingests on-demand notifications', function () {
             'user' => '',
             'channel' => 'mail',
             'class' => 'MyNotification',
-            'duration' => 0,
+            'duration' => 2500,
             'failed' => false,
         ],
     ]);
@@ -98,7 +99,7 @@ it('ingests notifications for notifiables', function () {
         [
             'v' => 1,
             't' => 'notification',
-            'timestamp' => 946688523.456789,
+            'timestamp' => 946688523.459289,
             'deploy' => 'v1.2.3',
             'server' => 'web-01',
             '_group' => hash('md5', 'MyNotification@anonymous'),
@@ -109,13 +110,13 @@ it('ingests notifications for notifiables', function () {
             'user' => '',
             'channel' => 'mail',
             'class' => 'MyNotification@anonymous',
-            'duration' => 0,
+            'duration' => 2500,
             'failed' => false,
         ],
         [
             'v' => 1,
             't' => 'notification',
-            'timestamp' => 946688523.456789,
+            'timestamp' => 946688523.461789,
             'deploy' => 'v1.2.3',
             'server' => 'web-01',
             '_group' => hash('md5', 'MyNotification@anonymous'),
@@ -126,13 +127,13 @@ it('ingests notifications for notifiables', function () {
             'user' => '',
             'channel' => 'mail',
             'class' => 'MyNotification@anonymous',
-            'duration' => 0,
+            'duration' => 2500,
             'failed' => false,
         ],
         [
             'v' => 1,
             't' => 'notification',
-            'timestamp' => 946688523.456789,
+            'timestamp' => 946688523.464289,
             'deploy' => 'v1.2.3',
             'server' => 'web-01',
             '_group' => hash('md5', 'MyNotification@anonymous'),
@@ -143,7 +144,7 @@ it('ingests notifications for notifiables', function () {
             'user' => '',
             'channel' => 'mail',
             'class' => 'MyNotification@anonymous',
-            'duration' => 0,
+            'duration' => 2500,
             'failed' => false,
         ],
     ]);
@@ -166,6 +167,8 @@ class MyNotification extends Notification
 
     public function toMail(object $notifiable)
     {
+        travelTo(now()->addMicroseconds(2500));
+
         return (new Illuminate\Mail\Mailable)
             ->subject('Hello World')
             ->to('dummy@example.com')

--- a/tests/Unit/Hooks/NotificationListenerTest.php
+++ b/tests/Unit/Hooks/NotificationListenerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Notifications\Events\NotificationSending;
 use Illuminate\Notifications\Events\NotificationSent;
 use Laravel\Nightwatch\Hooks\NotificationListener;
 use Laravel\Nightwatch\SensorManager;
@@ -11,7 +12,7 @@ it('gracefully handles exceptions', function () {
 
         public function __construct() {}
 
-        public function notification(NotificationSent $event): void
+        public function notification(NotificationSending|NotificationSent $event): void
         {
             $this->thrown = true;
 

--- a/tests/Unit/Hooks/NotificationListenerTest.php
+++ b/tests/Unit/Hooks/NotificationListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Notifications\Events\NotificationSent;
-use Laravel\Nightwatch\Hooks\NotificationSentListener;
+use Laravel\Nightwatch\Hooks\NotificationListener;
 use Laravel\Nightwatch\SensorManager;
 
 it('gracefully handles exceptions', function () {
@@ -21,7 +21,7 @@ it('gracefully handles exceptions', function () {
 
     $event = new NotificationSent(new stdClass, new stdClass, 'broadcast');
 
-    $handler = new NotificationSentListener($nightwatch);
+    $handler = new NotificationListener($nightwatch);
 
     $handler($event);
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

We currently don't capture notification durations.
This PR captures the duration by listening to the `NotificationSending` and `NotificationSent` events and calculating the difference between their timestamps.

We cannot capture failed notifications because the framework doesn't dispatch the `NotificationFailed` event. When a notification fails, it will show up as an exception record on the Nightwatch app.