### PR TITLE
Mail duration

### DIFF
--- a/src/Hooks/MailListener.php
+++ b/src/Hooks/MailListener.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nightwatch\Hooks;
 
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
@@ -11,7 +12,7 @@ use Throwable;
 /**
  * @internal
  */
-final class MessageSentListener
+final class MailListener
 {
     /**
      * @param  Core<RequestState|CommandState>  $nightwatch
@@ -22,7 +23,7 @@ final class MessageSentListener
         //
     }
 
-    public function __invoke(MessageSent $event): void
+    public function __invoke(MessageSending|MessageSent $event): void
     {
         try {
             $this->nightwatch->sensor->mail($event);

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -29,6 +29,7 @@ use Illuminate\Foundation\Http\Events\RequestHandled;
 use Illuminate\Http\Client\Factory as Http;
 use Illuminate\Log\Context\Repository as ContextRepository;
 use Illuminate\Log\LogManager;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Events\JobQueued;
@@ -54,7 +55,7 @@ use Laravel\Nightwatch\Hooks\HttpClientFactoryResolvedHandler;
 use Laravel\Nightwatch\Hooks\HttpKernelResolvedHandler;
 use Laravel\Nightwatch\Hooks\JobQueuedListener;
 use Laravel\Nightwatch\Hooks\LogoutListener;
-use Laravel\Nightwatch\Hooks\MessageSentListener;
+use Laravel\Nightwatch\Hooks\MailListener;
 use Laravel\Nightwatch\Hooks\NotificationSentListener;
 use Laravel\Nightwatch\Hooks\PreparingResponseListener;
 use Laravel\Nightwatch\Hooks\QueryExecutedListener;
@@ -294,7 +295,7 @@ final class NightwatchServiceProvider extends ServiceProvider
         /**
          * @see \Laravel\Nightwatch\Records\Mail
          */
-        $events->listen(MessageSent::class, (new MessageSentListener($core))(...));
+        $events->listen([MessageSending::class, MessageSent::class], (new MailListener($core))(...));
 
         //
         // -------------------------------------------------------------------------

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -9,6 +9,7 @@ use Illuminate\Console\Events\ScheduledTaskSkipped;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Queue\Events\JobAttempted;
@@ -128,7 +129,7 @@ class SensorManager
         $sensor($event);
     }
 
-    public function mail(MessageSent $event): void
+    public function mail(MessageSending|MessageSent $event): void
     {
         $sensor = $this->mailSensor ??= new MailSensor(
             executionState: $this->executionState,

--- a/src/Sensors/MailSensor.php
+++ b/src/Sensors/MailSensor.php
@@ -51,7 +51,7 @@ final class MailSensor
             throw new RuntimeException('No start time found for ['.$class.'].'); // @phpstan-ignore classConstant.nonObject
         }
 
-        $this->duration ??= (int) round(($now - $this->startTime) * 1_000_000);
+        $this->duration = (int) round(($now - $this->startTime) * 1_000_000);
         $this->executionState->mail++;
 
         $this->executionState->records->write(new Mail(

--- a/src/Sensors/MailSensor.php
+++ b/src/Sensors/MailSensor.php
@@ -2,20 +2,27 @@
 
 namespace Laravel\Nightwatch\Sensors;
 
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Laravel\Nightwatch\Clock;
 use Laravel\Nightwatch\Records\Mail;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
+use RuntimeException;
 
 use function count;
 use function hash;
+use function round;
 
 /**
  * @internal
  */
 final class MailSensor
 {
+    private ?float $startTime = null;
+
+    private ?int $duration = null;
+
     public function __construct(
         private RequestState|CommandState $executionState,
         private Clock $clock,
@@ -23,16 +30,28 @@ final class MailSensor
         //
     }
 
-    public function __invoke(MessageSent $event): void
+    public function __invoke(MessageSending|MessageSent $event): void
     {
+        if (isset($event->data['__laravel_notification'])) {
+            return;
+        }
+
         $now = $this->clock->microtime();
 
-        if (isset($event->data['__laravel_notification'])) {
+        if ($event instanceof MessageSending) {
+            $this->startTime = $now;
+            $this->duration = null;
+
             return;
         }
 
         $class = $event->data['__laravel_mailable'] ?? '';
 
+        if ($this->startTime === null) {
+            throw new RuntimeException('No start time found for ['.$class.'].'); // @phpstan-ignore classConstant.nonObject
+        }
+
+        $this->duration ??= (int) round(($now - $this->startTime) * 1_000_000);
         $this->executionState->mail++;
 
         $this->executionState->records->write(new Mail(
@@ -52,8 +71,8 @@ final class MailSensor
             cc: count($event->message->getCc()),
             bcc: count($event->message->getBcc()),
             attachments: count($event->message->getAttachments()),
-            duration: 0, // TODO
-            failed: false, // TODO
+            duration: $this->duration,
+            failed: false, // TODO: The framework doesn't dispatch a failed event.
         ));
     }
 }

--- a/src/Sensors/MailSensor.php
+++ b/src/Sensors/MailSensor.php
@@ -48,7 +48,7 @@ final class MailSensor
         $class = $event->data['__laravel_mailable'] ?? '';
 
         if ($this->startTime === null) {
-            throw new RuntimeException('No start time found for ['.$class.'].'); // @phpstan-ignore classConstant.nonObject
+            throw new RuntimeException("No start time found for [{$class}].");
         }
 
         $this->duration = (int) round(($now - $this->startTime) * 1_000_000);

--- a/tests/Feature/Sensors/MailSensorTest.php
+++ b/tests/Feature/Sensors/MailSensorTest.php
@@ -2,15 +2,18 @@
 
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Mailable;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Illuminate\Support\Facades\Route;
 
 use function Pest\Laravel\post;
+use function Pest\Laravel\travelTo;
 
 beforeAll(function () {
     forceRequestExecutionState();
@@ -42,6 +45,10 @@ it('ingests mails', function () {
         ])->send((new MyTestMail)->html('')->subject('Welcome!')->attachData('hunter2', 'password.txt'));
     });
 
+    Event::listen(MessageSending::class, function ($event) {
+        travelTo(now()->addMicroseconds(2500));
+    });
+
     $response = post('/users');
 
     $response->assertOk();
@@ -51,7 +58,7 @@ it('ingests mails', function () {
         [
             'v' => 1,
             't' => 'mail',
-            'timestamp' => 946688523.456789,
+            'timestamp' => 946688523.459289,
             'deploy' => 'v1.2.3',
             'server' => 'web-01',
             '_group' => md5('MyTestMail'),
@@ -67,7 +74,7 @@ it('ingests mails', function () {
             'cc' => 2,
             'bcc' => 1,
             'attachments' => 1,
-            'duration' => 0,
+            'duration' => 2500,
             'failed' => false,
         ],
     ]);

--- a/tests/Unit/Hooks/MailListenerTest.php
+++ b/tests/Unit/Hooks/MailListenerTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use Illuminate\Mail\Events\MessageSending;
 use Illuminate\Mail\Events\MessageSent;
 use Illuminate\Mail\SentMessage;
-use Laravel\Nightwatch\Hooks\MessageSentListener;
+use Laravel\Nightwatch\Hooks\MailListener;
 use Laravel\Nightwatch\SensorManager;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\SentMessage as MailerSentMessage;
@@ -16,7 +17,7 @@ it('gracefully handles exceptions', function () {
 
         public function __construct() {}
 
-        public function mail(MessageSent $event): void
+        public function mail(MessageSending|MessageSent $event): void
         {
             $this->thrown = true;
 
@@ -26,7 +27,7 @@ it('gracefully handles exceptions', function () {
     $event = new MessageSent(new SentMessage(new MailerSentMessage(
         new RawMessage('Hello world'), new Envelope(new Address('nightwatch@laravel.com'), [new Address('tim@laravel.com')])
     )));
-    $handler = new MessageSentListener($nightwatch);
+    $handler = new MailListener($nightwatch);
 
     $handler($event);
 


### PR DESCRIPTION
This PR captures the mail duration by listening to the `MessageSending` and `MessageSent` events and calculating the difference between their timestamps.

We cannot capture failed mail because the framework doesn't dispatch failed events. Instead, an exception will be recorded when a mail fails.