### PR TITLE
Allow customisation of captured user details

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nightwatch;
 
+use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Nightwatch\Contracts\LocalIngest;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\State\CommandState;
@@ -13,6 +14,11 @@ use Throwable;
  */
 final class Core
 {
+    /**
+     * @var null|(callable(Authenticatable): array{id: mixed, name?: mixed, username?: mixed})
+     */
+    public $userDetailsResolver = null;
+
     /**
      * @param  TState  $state
      */
@@ -37,6 +43,11 @@ final class Core
         } catch (Throwable $e) {
             Nightwatch::unrecoverableExceptionOccurred($e);
         }
+    }
+
+    public function user(callable $callback): void
+    {
+        $this->userDetailsResolver = $callback;
     }
 
     /**

--- a/src/Facades/Nightwatch.php
+++ b/src/Facades/Nightwatch.php
@@ -9,6 +9,7 @@ use function call_user_func;
 
 /**
  * @method static void report(\Throwable $e)
+ * @method static void user(callable $callback)
  *
  * @see \Laravel\Nightwatch\Core
  */

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -429,7 +429,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                 currentExecutionStageStartedAtMicrotime: $this->timestamp,
                 deploy: $this->nightwatchConfig['deployment'] ?? '',
                 server: $this->nightwatchConfig['server'] ?? '',
-                user: new UserProvider($auth),
+                user: new UserProvider($auth, fn () => $this->core->userDetailsResolver),
             );
         } else {
             return new CommandState(

--- a/src/Sensors/UserSensor.php
+++ b/src/Sensors/UserSensor.php
@@ -25,9 +25,9 @@ final class UserSensor
 
         $this->requestState->records->write(new User(
             timestamp: $this->clock->microtime(),
-            id: $details['id'],
-            name: $details['name'],
-            username: $details['username'],
+            id: (string) $details['id'], // @phpstan-ignore cast.string
+            name: (string) ($details['name'] ?? ''), // @phpstan-ignore cast.string
+            username: (string) ($details['username'] ?? ''), // @phpstan-ignore cast.string
         ));
     }
 }

--- a/tests/Feature/Sensors/UserSensorTest.php
+++ b/tests/Feature/Sensors/UserSensorTest.php
@@ -3,7 +3,9 @@
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Route;
+use Laravel\Nightwatch\Facades\Nightwatch;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
@@ -69,4 +71,118 @@ it('does not capture guests', function () {
     $response->assertOk();
     $ingest->assertWrittenTimes(1);
     $ingest->assertLatestWrite('user:*', []);
+});
+
+it('can customize the capture of user details', function () {
+    $ingest = fakeIngest();
+    Route::get('/users', fn () => []);
+    $user = User::make([
+        'id' => '567',
+        'name' => 'Tim MacDonald',
+        'email' => 'tim@laravel.com',
+    ]);
+    Nightwatch::user(fn (Authenticatable $user) => [
+        'id' => '123',
+        'name' => 'Tim',
+        'username' => 'timacdonald',
+    ]);
+
+    $response = actingAs($user)->get('/users');
+
+    $response->assertOk();
+    $ingest->assertWrittenTimes(1);
+    $ingest->assertLatestWrite('user:*', [[
+        'v' => 1,
+        't' => 'user',
+        'timestamp' => 946688523.456789,
+        'id' => '123',
+        'name' => 'Tim',
+        'username' => 'timacdonald',
+    ]]);
+});
+
+it('handles authenticatable objects without name or email properties', function () {
+    $ingest = fakeIngest();
+    Route::get('/users', fn () => []);
+    $user = new class implements Authenticatable
+    {
+        public function getAuthIdentifierName()
+        {
+            return 'id-name';
+        }
+
+        /**
+         * Get the unique identifier for the user.
+         *
+         * @return mixed
+         */
+        public function getAuthIdentifier()
+        {
+            return '123';
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password-name';
+        }
+
+        public function getAuthPassword()
+        {
+            return 'hunter2';
+        }
+
+        public function getRememberToken()
+        {
+            return 'remember-me-token';
+        }
+
+        public function setRememberToken($value)
+        {
+            //
+        }
+
+        public function getRememberTokenName()
+        {
+            return 'remember-me-token-name';
+        }
+    };
+
+    $response = actingAs($user)->get('/users');
+
+    $response->assertOk();
+    $ingest->assertWrittenTimes(1);
+    $ingest->assertLatestWrite('user:*', [[
+        'v' => 1,
+        't' => 'user',
+        'timestamp' => 946688523.456789,
+        'id' => '123',
+        'name' => '',
+        'username' => '',
+    ]]);
+});
+
+it('can only collect the user id', function () {
+    $ingest = fakeIngest();
+    Route::get('/users', fn () => []);
+    $user = User::make([
+        'id' => '567',
+        'name' => 'Tim MacDonald',
+        'email' => 'tim@laravel.com',
+    ]);
+    Nightwatch::user(fn (Authenticatable $user) => [
+        'id' => '123',
+    ]);
+
+    $response = actingAs($user)->get('/users');
+
+    $response->assertOk();
+    $ingest->assertWrittenTimes(1);
+    $ingest->assertLatestWrite('user:*', [[
+        'v' => 1,
+        't' => 'user',
+        'timestamp' => 946688523.456789,
+        'id' => '123',
+        'name' => '',
+        'username' => '',
+    ]]);
 });

--- a/tests/Unit/UserProviderTest.php
+++ b/tests/Unit/UserProviderTest.php
@@ -8,16 +8,14 @@ it('limits the length of the user identifier', function () {
     Auth::login(new GenericUser([
         'id' => str_repeat('x', 1000),
     ]));
-    /** @var UserProvider */
-    $provider = app(UserProvider::class);
+    $provider = new UserProvider(app('auth'), fn () => []);
 
     expect(Auth::id())->toHaveLength(1000);
     expect($provider->id())->toEqual(str_repeat('x', 255));
 });
 
 it('can lazily retrieve the user', function () {
-    /** @var UserProvider */
-    $provider = app(UserProvider::class);
+    $provider = new UserProvider(app('auth'), fn () => []);
 
     $id = $provider->id();
 
@@ -29,8 +27,7 @@ it('can lazily retrieve the user', function () {
 });
 
 it('can remember an authenticated user and limits the length of their identifier', function () {
-    /** @var UserProvider */
-    $provider = app(UserProvider::class);
+    $provider = new UserProvider(app('auth'), fn () => []);
     $provider->remember($user = new GenericUser([
         'id' => str_repeat('x', 1000),
     ]));


### PR DESCRIPTION
Customise all fields:

```php
// app/Providers/AppServiceProvider.php

public function boot()
{
    Nightwatch::user(fn (Authenticatable $user) => [
        'id' => /* ... */,
        'name' => /* ... */,
        'username' => /* ... */,
    ]);
}
```

Only collect the user's ID:

```php
// app/Providers/AppServiceProvider.php

public function boot()
{
    Nightwatch::user(fn (Authenticatable $user) => [
        'id' => /* ... */,
    ]);
}
```

I'll follow up with a PR to allow customisation of the user resolution logic.