### PR TITLE
Improve local ci check performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .env
 /.phpunit.result.cache
+/.pint.cache
+/.pint.ci.cache
 /composer.lock
 /node_modules
 /phpunit.xml

--- a/agent/.gitignore
+++ b/agent/.gitignore
@@ -1,6 +1,8 @@
 /.box_dump
 /.env.testing
 /.phpunit.result.cache
+/.pint.cache
+/.pint.ci.cache
 /box.json
 /node_modules
 /phpstan.neon

--- a/agent/composer.json
+++ b/agent/composer.json
@@ -54,9 +54,9 @@
             "@composer lint"
         ],
         "lint": [
-            "@php vendor/bin/pint --config=pint.ci.json",
-            "@php vendor/bin/pint",
-            "@php vendor/bin/phpstan --memory-limit=-1 --verbose"
+            "@php vendor/bin/phpstan --memory-limit=-1 --verbose",
+            "@php vendor/bin/pint --config=pint.ci.json --cache-file=.pint.ci.cache",
+            "@php vendor/bin/pint --cache-file=.pint.cache"
         ],
         "test": [
             "@php vendor/bin/pest"

--- a/composer.json
+++ b/composer.json
@@ -90,9 +90,9 @@
             "@composer lint"
         ],
         "lint": [
-            "@php vendor/bin/pint --config=pint.ci.json",
-            "@php vendor/bin/pint",
-            "@php vendor/bin/phpstan --memory-limit=-1 --verbose"
+            "@php vendor/bin/phpstan --memory-limit=-1 --verbose",
+            "@php vendor/bin/pint --config=pint.ci.json --cache-file=.pint.ci.cache",
+            "@php vendor/bin/pint --cache-file=.pint.cache"
         ],
         "test": [
             "@php vendor/bin/testbench package:purge-skeleton",


### PR DESCRIPTION
Improved ordering and performance of the `composer ci` command.

1. Run PHPStan before Pint

Generally always want static analysis feedback before styling fixes.

This improves the feedback loop speed when there are potential issues.

2. Dedicated cache files for both `pint` runs

This greatly improves the speed of Pint. Because Pint, and PHP-CS-Fixer, use the config as part of the cache, every time I run the `composer ci` command it hits a cold cache for _both_ runs of `pint`. Now they are both lightning fast.