### PR TITLE
Always read base url from env

### DIFF
--- a/src/Console/AgentCommand.php
+++ b/src/Console/AgentCommand.php
@@ -21,8 +21,7 @@ final class AgentCommand extends Command
         {--auth-timeout=}
         {--ingest-connection-timeout=}
         {--ingest-timeout=}
-        {--server=}
-        {--base-url=}';
+        {--server=}';
 
     /**
      * @var string
@@ -39,8 +38,6 @@ final class AgentCommand extends Command
     public function handle(): void
     {
         $refreshToken = $this->token;
-
-        $baseUrl = $this->option('base-url');
 
         $listenOn = $this->option('listen-on');
 


### PR DESCRIPTION
We expose a `--base-url` argument for the agent's artisan command.

There are only a few apps that will ever use this and they are all internal.

Removing it to reduce the command's API to only inputs that general users will interact with.

We will update the internal apps to support this without the flag.