### PR TITLE
add support for SingleStore driver

### DIFF
--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -61,7 +61,7 @@ final class QuerySensor
 
     private function hash(QueryExecuted $event): string
     {
-        if (! in_array($event->connection->getDriverName(), ['mariadb', 'mysql', 'pgsql', 'sqlite', 'sqlsrv'], true)) {
+        if (! in_array($event->connection->getDriverName(), ['mariadb', 'mysql', 'pgsql', 'sqlite', 'sqlsrv', 'singlestore'], true)) {
             return hash('xxh128', "{$event->connectionName},{$event->sql}");
         }
 


### PR DESCRIPTION
SingleStore is wire compatible with MySQL, so it should be treated the same

 https://github.com/singlestore-labs/singlestoredb-laravel-driver