### PR TITLE
Handle `null` cache keys

### DIFF
--- a/src/Sensors/CacheEventSensor.php
+++ b/src/Sensors/CacheEventSensor.php
@@ -100,7 +100,7 @@ final class CacheEventSensor
             execution_stage: $this->executionState->stage,
             user: $this->executionState->user->id(),
             store: $storeName,
-            key: $event->key,
+            key: $event->key ?? '',
             type: $type,
             duration: $duration,
             ttl: in_array($event::class, [KeyWritten::class, KeyWriteFailed::class], true) ? ($event->seconds ?? 0) : 0,

--- a/src/Sensors/CacheEventSensor.php
+++ b/src/Sensors/CacheEventSensor.php
@@ -100,7 +100,7 @@ final class CacheEventSensor
             execution_stage: $this->executionState->stage,
             user: $this->executionState->user->id(),
             store: $storeName,
-            key: $event->key ?? '',
+            key: $event->key ?? '', // @phpstan-ignore nullCoalesce.property
             type: $type,
             duration: $duration,
             ttl: in_array($event::class, [KeyWritten::class, KeyWriteFailed::class], true) ? ($event->seconds ?? 0) : 0,

--- a/tests/Feature/Sensors/CacheEventSensorTest.php
+++ b/tests/Feature/Sensors/CacheEventSensorTest.php
@@ -534,4 +534,24 @@ class CacheEventSensorTest extends TestCase
             ],
         ]);
     }
+
+    public function test_it_can_capture_null_cache_keys(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/tests', function () {
+            Cache::get(null);
+        });
+
+        $response = $this->get('/tests');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite(function ($write) {
+            $this->assertCount(2, $write);
+
+            return true;
+        });
+        $ingest->assertLatestWrite('cache-event:0.key', '');
+        $ingest->assertLatestWrite('request:0.url', 'http://localhost/tests');
+    }
 }

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -680,8 +680,11 @@ class ExceptionSensorTest extends TestCase
     public function test_it_reports_internally_reported_exceptions_as_handled()
     {
         $ingest = $this->fakeIngest();
+        $this->core->sensor->cacheEventSensor = function () {
+            throw new RuntimeException('Whoops!');
+        };
         Route::get('/test', function () {
-            Cache::get(null);
+            Cache::get('key');
         });
 
         $response = $this->get('/test');


### PR DESCRIPTION
We've had reports of internal exceptions being thrown because `null` cache keys have been mistakenly used, e.g., `Cache::get($key)` where `$key` was unexpectedly `null`.

Although Nightwatch handled this gracefully without interrupting the execution of the project, it does report an internal-facing error. We can safely fallback to an empty string in this scenario.