### PR TITLE
Handle `null` connection name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "symfony/http-foundation": "^6.0|^7.0"
     },
     "require-dev": {
+        "ext-pdo": "*",
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/psr7": "^2.0",
         "laravel/horizon": "^5.4",

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -55,7 +55,7 @@ final class QuerySensor
             file: $file ?? '',
             line: $line ?? 0,
             duration: $durationInMicroseconds,
-            connection: $event->connectionName ?? '',
+            connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
         ));
     }
 

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -55,7 +55,7 @@ final class QuerySensor
             file: $file ?? '',
             line: $line ?? 0,
             duration: $durationInMicroseconds,
-            connection: $event->connectionName,
+            connection: $event->connectionName ?? '',
         ));
     }
 

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
 use MongoDB\Laravel\Connection as MongoDbConnection;
+use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
@@ -318,5 +319,17 @@ class QuerySensorTest extends TestCase
             '😎',
             $ingest->latestWriteAsString(),
         );
+    }
+
+    public function test_it_can_capture_null_connection_name()
+    {
+        $ingest = $this->fakeIngest();
+        $connection = new Connection(new PDO('sqlite::memory:'), 'database', 'prefix', []);
+
+        Event::dispatch(new QueryExecuted('select * from users', [], 1, $connection));
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection', '');
     }
 }


### PR DESCRIPTION
We have had reports of `null` connection names causing internal exceptions. Although Nightwatch gracefully handled the exception, we would be better off falling back to an empty string and capturing the query.