### PR TITLE
Add support for ignoring queued jobs via configuration

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -18,6 +18,7 @@ return [
         'ignore_notifications' => env('NIGHTWATCH_IGNORE_NOTIFICATIONS', false),
         'ignore_outgoing_requests' => env('NIGHTWATCH_IGNORE_OUTGOING_REQUESTS', false),
         'ignore_queries' => env('NIGHTWATCH_IGNORE_QUERIES', false),
+        'ignore_queued_jobs' => env('NIGHTWATCH_IGNORE_QUEUED_JOBS', false),
     ],
 
     'ingest' => [

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -158,6 +158,10 @@ trait CapturesState
             return;
         }
 
+        if ($this->config['filtering']['ignore_queued_jobs']) {
+            return;
+        }
+
         $this->sensor->queuedJob($event);
     }
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -40,6 +40,7 @@ final class Core
      *         ignore_notifications: bool,
      *         ignore_outgoing_requests: bool,
      *         ignore_queries: bool,
+     *         ignore_queued_jobs: bool,
      *     },
      * }  $config
      */

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -99,6 +99,7 @@ final class NightwatchServiceProvider extends ServiceProvider
      *         ignore_notifications?: bool,
      *         ignore_outgoing_requests?: bool,
      *         ignore_queries?: bool,
+     *         ignore_queued_jobs?: bool,
      *     },
      *     token?: string,
      *     deployment?: string,
@@ -245,6 +246,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                     'ignore_notifications' => (bool) ($this->nightwatchConfig['filtering']['ignore_notifications'] ?? false),
                     'ignore_outgoing_requests' => (bool) ($this->nightwatchConfig['filtering']['ignore_outgoing_requests'] ?? false),
                     'ignore_queries' => (bool) ($this->nightwatchConfig['filtering']['ignore_queries'] ?? false),
+                    'ignore_queued_jobs' => (bool) ($this->nightwatchConfig['filtering']['ignore_queued_jobs'] ?? false),
                 ],
             ],
         ));

--- a/tests/Fakes/DummyJob.php
+++ b/tests/Fakes/DummyJob.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fakes;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class DummyJob implements ShouldQueue
+{
+    use Dispatchable;
+    use Queueable;
+
+    public function handle() {}
+}

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
+use Tests\Fakes\DummyJob;
 use Tests\TestCase;
 
 class FilteringTest extends TestCase
@@ -117,5 +118,24 @@ class FilteringTest extends TestCase
         }
 
         $this->assertSame(10, $this->core->executionState->outgoingRequests);
+    }
+
+    public function test_it_can_ignore_queued_job(): void
+    {
+        $this->core->config['filtering']['ignore_queued_jobs'] = true;
+
+        for ($i = 0; $i < 10; $i++) {
+            DummyJob::dispatch();
+        }
+
+        $this->assertSame(0, $this->core->executionState->queuedJobs ?? 0);
+
+        $this->core->config['filtering']['ignore_queued_jobs'] = false;
+
+        for ($i = 0; $i < 10; $i++) {
+            DummyJob::dispatch();
+        }
+
+        $this->assertSame(10, $this->core->executionState->queuedJobs ?? 10);
     }
 }


### PR DESCRIPTION
We run some Microservices that dispatch millions of jobs per day which results in sampling even just 10% eating up our quota pretty fast. This allows users to ignore queued jobs from being reported.