### PR TITLE
Allow consumers of the SDK to override the ID of users

### DIFF
--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -88,7 +88,7 @@ final class UserProvider
     private function currentUserId(): string
     {
         try {
-            return Str::tinyText((string) $this->withAuth(static fn ($auth) => $auth->id()));
+            return Str::tinyText((string) $this->withAuth(fn ($auth) => $this->idFromAuthOrProvider($auth->id())                ));
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
@@ -99,12 +99,23 @@ final class UserProvider
     private function rememberedUserId(): string
     {
         try {
-            return Str::tinyText((string) $this->rememberedUser?->getAuthIdentifier());  // @phpstan-ignore cast.string
+            return Str::tinyText($this->idFromAuthOrProvider($this->rememberedUser?->getAuthIdentifier()));
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
             return '';
         }
+    }
+
+    private function idFromAuthOrProvider(int|string|null $id): string
+    {
+        // If we have an ID from the details, use that.
+        $details = $this->details();
+        if (isset($details['id'])) {
+            $id = (string) $details['id'];
+        }
+
+        return $id;
     }
 
     /**


### PR DESCRIPTION
I've been in contact with Tim in support, because I would like to control the ID that is passed to Nightwatch.
This cannot be done as of now, as the events are logged with `->id()`, which doesn't look at the user details provider.

There are a couple of reasons you'd want to be able to do this. For example if you have different Authenticable types, each backed by a different eloquent model. In this situation, User with id 42 and Admin with id 42 would be considered the same User in nightwatch. If you try to do this anyway, you break the UI in Nightwatch (see my bug report for screenshots).

I believe this change would avoid having two sources of ID's, and allow people with multiple eloquent models (or GDPR concerns) to use this package.

I've adjusted the tests to match how the `UserProvider` is actually instantiated inside the NightwatchServiceProvider.

I'm currently using this change on our Nightwatch account, and so far it has worked like a charm :-)

Edit: I've run the static analysis and `pint` locally. I'm not sure how to supply the keys to run the PR checks.