### PR TITLE
Add support for log levels

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -18,6 +18,7 @@ return [
         'ignore_notifications' => env('NIGHTWATCH_IGNORE_NOTIFICATIONS', false),
         'ignore_outgoing_requests' => env('NIGHTWATCH_IGNORE_OUTGOING_REQUESTS', false),
         'ignore_queries' => env('NIGHTWATCH_IGNORE_QUERIES', false),
+        'log_level' => env('NIGHTWATCH_LOG_LEVEL', env('LOG_LEVEL', 'debug')),
     ],
 
     'ingest' => [

--- a/src/Factories/Logger.php
+++ b/src/Factories/Logger.php
@@ -34,7 +34,7 @@ final class Logger
         return new Monolog(
             name: 'nightwatch',
             handlers: [
-                new LogHandler($this->nightwatch),
+                new LogHandler($this->nightwatch, $config),
             ],
             processors: [
                 new LogRecordProcessor($this->nightwatch, 'Y-m-d H:i:s.uP'),

--- a/src/Factories/Logger.php
+++ b/src/Factories/Logger.php
@@ -27,14 +27,14 @@ final class Logger
     }
 
     /**
-     * @param  array<string, mixed>&array{level?: \Psr\Log\LogLevel::*}  $config
+     * @param  array<string, mixed>&array{level: \Psr\Log\LogLevel::*}  $config
      */
     public function __invoke(array $config): LoggerInterface
     {
         return new Monolog(
             name: 'nightwatch',
             handlers: [
-                new LogHandler($this->nightwatch, Monolog::toMonologLevel($config['level'] ?? 'debug')),
+                new LogHandler($this->nightwatch, Monolog::toMonologLevel($config['level'])),
             ],
             processors: [
                 new LogRecordProcessor($this->nightwatch, 'Y-m-d H:i:s.uP'),

--- a/src/Factories/Logger.php
+++ b/src/Factories/Logger.php
@@ -27,7 +27,7 @@ final class Logger
     }
 
     /**
-     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>&array{level?: \Psr\Log\LogLevel::*}  $config
      */
     public function __invoke(array $config): LoggerInterface
     {

--- a/src/Factories/Logger.php
+++ b/src/Factories/Logger.php
@@ -34,7 +34,7 @@ final class Logger
         return new Monolog(
             name: 'nightwatch',
             handlers: [
-                new LogHandler($this->nightwatch, $config),
+                new LogHandler($this->nightwatch, Monolog::toMonologLevel($config['level'] ?? 'debug')),
             ],
             processors: [
                 new LogRecordProcessor($this->nightwatch, 'Y-m-d H:i:s.uP'),

--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -6,6 +6,7 @@ use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Monolog\Handler\HandlerInterface;
+use Monolog\Level;
 use Monolog\Logger;
 use Monolog\LogRecord;
 use Throwable;
@@ -15,6 +16,8 @@ use Throwable;
  */
 final class LogHandler implements HandlerInterface
 {
+    protected Level $level;
+
     /**
      * @param  Core<RequestState|CommandState>  $nightwatch
      */
@@ -27,9 +30,9 @@ final class LogHandler implements HandlerInterface
 
     public function isHandling(LogRecord $record): bool
     {
-        $level = Logger::toMonologLevel($this->config['level'] ?? 'debug');
+        $this->level ??= Logger::toMonologLevel($this->config['level'] ?? 'debug');
 
-        return $this->nightwatch->shouldCaptureLogs() && $level->includes($record->level);
+        return $this->nightwatch->shouldCaptureLogs() && $this->level->includes($record->level);
     }
 
     public function handle(LogRecord $record): bool

--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -7,7 +7,6 @@ use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Level;
-use Monolog\Logger;
 use Monolog\LogRecord;
 use Throwable;
 
@@ -16,23 +15,18 @@ use Throwable;
  */
 final class LogHandler implements HandlerInterface
 {
-    protected Level $level;
-
     /**
      * @param  Core<RequestState|CommandState>  $nightwatch
-     * @param  array{level?: \Psr\Log\LogLevel::*}  $config
      */
     public function __construct(
         private Core $nightwatch,
-        private array $config,
+        private Level $level,
     ) {
         //
     }
 
     public function isHandling(LogRecord $record): bool
     {
-        $this->level ??= Logger::toMonologLevel($this->config['level'] ?? 'debug');
-
         return $this->nightwatch->shouldCaptureLogs() && $this->level->includes($record->level);
     }
 

--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -6,6 +6,7 @@ use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Monolog\Handler\HandlerInterface;
+use Monolog\Logger;
 use Monolog\LogRecord;
 use Throwable;
 
@@ -19,13 +20,16 @@ final class LogHandler implements HandlerInterface
      */
     public function __construct(
         private Core $nightwatch,
+        private array $config,
     ) {
         //
     }
 
     public function isHandling(LogRecord $record): bool
     {
-        return $this->nightwatch->shouldCaptureLogs();
+        $level = Logger::toMonologLevel($this->config['level'] ?? 'debug');
+
+        return $this->nightwatch->shouldCaptureLogs() && $level->includes($record->level);
     }
 
     public function handle(LogRecord $record): bool

--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -20,6 +20,7 @@ final class LogHandler implements HandlerInterface
 
     /**
      * @param  Core<RequestState|CommandState>  $nightwatch
+     * @param  array{level?: \Psr\Log\LogLevel::*}  $config
      */
     public function __construct(
         private Core $nightwatch,

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -100,6 +100,7 @@ final class NightwatchServiceProvider extends ServiceProvider
      *         ignore_notifications?: bool,
      *         ignore_outgoing_requests?: bool,
      *         ignore_queries?: bool,
+     *         log_level?: \Psr\Log\LogLevel::*,
      *     },
      *     token?: string,
      *     deployment?: string,
@@ -184,7 +185,7 @@ final class NightwatchServiceProvider extends ServiceProvider
             $this->config->set('logging.channels.nightwatch', [
                 'driver' => 'custom',
                 'via' => Logger::class,
-                'level' => $this->config->get('nightwatch.filtering.log_level'),
+                'level' => $this->nightwatchConfig['filtering']['log_level'] ?? 'debug',
             ]);
         }
 

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -184,6 +184,7 @@ final class NightwatchServiceProvider extends ServiceProvider
             $this->config->set('logging.channels.nightwatch', [
                 'driver' => 'custom',
                 'via' => Logger::class,
+                'level' => $this->config->get('nightwatch.filtering.log_level'),
             ]);
         }
 

--- a/tests/Feature/Sensors/LogSensorTest.php
+++ b/tests/Feature/Sensors/LogSensorTest.php
@@ -21,6 +21,9 @@ class LogSensorTest extends TestCase
     {
         $this->forceRequestExecutionState();
 
+        Env::getRepository()->set('LOG_LEVEL', 'debug');
+        Env::getRepository()->set('NIGHTWATCH_LOG_LEVEL', 'debug');
+
         parent::setUp();
 
         $this->setDeploy('v1.2.3');
@@ -264,10 +267,11 @@ class LogSensorTest extends TestCase
 
     public function test_it_respects_the_log_level()
     {
+        Env::getRepository()->clear('NIGHTWATCH_LOG_LEVEL');
         Env::getRepository()->set('LOG_LEVEL', 'warning');
 
         $this->refreshApplication();
-        $this->setUp();
+        parent::setUp();
 
         $ingest = $this->fakeIngest();
 
@@ -300,7 +304,7 @@ class LogSensorTest extends TestCase
         Env::getRepository()->set('NIGHTWATCH_LOG_LEVEL', 'warning');
 
         $this->refreshApplication();
-        $this->setUp();
+        parent::setUp();
 
         $ingest = $this->fakeIngest();
 

--- a/tests/Feature/Sensors/LogSensorTest.php
+++ b/tests/Feature/Sensors/LogSensorTest.php
@@ -21,8 +21,8 @@ class LogSensorTest extends TestCase
     {
         $this->forceRequestExecutionState();
 
-        Env::getRepository()->set('LOG_LEVEL', 'debug');
-        Env::getRepository()->set('NIGHTWATCH_LOG_LEVEL', 'debug');
+        Env::getRepository()->clear('LOG_LEVEL');
+        Env::getRepository()->clear('NIGHTWATCH_LOG_LEVEL');
 
         parent::setUp();
 
@@ -267,7 +267,6 @@ class LogSensorTest extends TestCase
 
     public function test_it_respects_the_log_level()
     {
-        Env::getRepository()->clear('NIGHTWATCH_LOG_LEVEL');
         Env::getRepository()->set('LOG_LEVEL', 'warning');
 
         $this->refreshApplication();

--- a/tests/Feature/Sensors/LogSensorTest.php
+++ b/tests/Feature/Sensors/LogSensorTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Sensors;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Monolog\LogRecord;
@@ -259,5 +260,70 @@ class LogSensorTest extends TestCase
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('log:0.context', '{"binary":"��#"}');
         $ingest->assertLatestWrite('log:0.extra', '{"binary":"��#"}');
+    }
+
+    public function test_it_respects_the_log_level()
+    {
+        Env::getRepository()->set('LOG_LEVEL', 'warning');
+
+        $this->refreshApplication();
+        $this->setUp();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function (): void {
+            Log::channel('nightwatch')->debug('hello world');
+            Log::channel('nightwatch')->info('hello world');
+            Log::channel('nightwatch')->notice('hello world');
+            Log::channel('nightwatch')->warning('hello world');
+            Log::channel('nightwatch')->error('hello world');
+            Log::channel('nightwatch')->critical('hello world');
+            Log::channel('nightwatch')->alert('hello world');
+            Log::channel('nightwatch')->emergency('hello world');
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('request:0.logs', 5);
+        $ingest->assertLatestWrite('log:0.level', 'warning');
+        $ingest->assertLatestWrite('log:1.level', 'error');
+        $ingest->assertLatestWrite('log:2.level', 'critical');
+        $ingest->assertLatestWrite('log:3.level', 'alert');
+        $ingest->assertLatestWrite('log:4.level', 'emergency');
+    }
+
+    public function test_it_respects_the_nightwatch_log_level()
+    {
+        Env::getRepository()->set('LOG_LEVEL', 'debug');
+        Env::getRepository()->set('NIGHTWATCH_LOG_LEVEL', 'warning');
+
+        $this->refreshApplication();
+        $this->setUp();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function (): void {
+            Log::channel('nightwatch')->debug('hello world');
+            Log::channel('nightwatch')->info('hello world');
+            Log::channel('nightwatch')->notice('hello world');
+            Log::channel('nightwatch')->warning('hello world');
+            Log::channel('nightwatch')->error('hello world');
+            Log::channel('nightwatch')->critical('hello world');
+            Log::channel('nightwatch')->alert('hello world');
+            Log::channel('nightwatch')->emergency('hello world');
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('request:0.logs', 5);
+        $ingest->assertLatestWrite('log:0.level', 'warning');
+        $ingest->assertLatestWrite('log:1.level', 'error');
+        $ingest->assertLatestWrite('log:2.level', 'critical');
+        $ingest->assertLatestWrite('log:3.level', 'alert');
+        $ingest->assertLatestWrite('log:4.level', 'emergency');
     }
 }

--- a/tests/Unit/Hooks/LogHandlerTest.php
+++ b/tests/Unit/Hooks/LogHandlerTest.php
@@ -21,7 +21,7 @@ class LogHandlerTest extends TestCase
         };
         $record = new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Debug, 'hello world');
 
-        $handler = new LogHandler($this->core);
+        $handler = new LogHandler($this->core, []);
         $handler->handle($record);
 
         $this->assertTrue($thrownInLogSensor);

--- a/tests/Unit/Hooks/LogHandlerTest.php
+++ b/tests/Unit/Hooks/LogHandlerTest.php
@@ -24,7 +24,7 @@ class LogHandlerTest extends TestCase
         };
         $record = new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Debug, 'hello world');
 
-        $handler = new LogHandler($this->core, []);
+        $handler = new LogHandler($this->core, Level::Debug);
         $handler->handle($record);
 
         $this->assertTrue($thrownInLogSensor);
@@ -59,7 +59,7 @@ class LogHandlerTest extends TestCase
             new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Emergency, 'hello world'),
         ];
 
-        $handler = new LogHandler($this->core, ['level' => $level]);
+        $handler = new LogHandler($this->core, Level::fromName($level));
 
         foreach ($records as $record) {
             if (in_array($record->level->toPsrLogLevel(), $expected, true)) {

--- a/tests/Unit/Hooks/LogHandlerTest.php
+++ b/tests/Unit/Hooks/LogHandlerTest.php
@@ -6,8 +6,11 @@ use Carbon\CarbonImmutable;
 use Laravel\Nightwatch\Hooks\LogHandler;
 use Monolog\Level;
 use Monolog\LogRecord;
+use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 use Tests\TestCase;
+
+use function in_array;
 
 class LogHandlerTest extends TestCase
 {
@@ -40,5 +43,44 @@ class LogHandlerTest extends TestCase
         $this->assertTrue($handler->isHandling($record));
         $this->assertFalse($thrownInLogSensor);
         $this->assertSame(2, $this->core->executionState->exceptions);
+    }
+
+    #[DataProvider('logLevelProvider')]
+    public function test_it_respects_the_log_level(string $level, array $expected): void
+    {
+        $records = [
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Debug, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Info, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Notice, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Warning, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Error, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Critical, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Alert, 'hello world'),
+            new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Emergency, 'hello world'),
+        ];
+
+        $handler = new LogHandler($this->core, ['level' => $level]);
+
+        foreach ($records as $record) {
+            if (in_array($record->level->toPsrLogLevel(), $expected, true)) {
+                $this->assertTrue($handler->isHandling($record));
+            } else {
+                $this->assertFalse($handler->isHandling($record));
+            }
+        }
+    }
+
+    public static function logLevelProvider(): array
+    {
+        return [
+            ['debug', ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']],
+            ['info', ['info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']],
+            ['notice', ['notice', 'warning', 'error', 'critical', 'alert', 'emergency']],
+            ['warning', ['warning', 'error', 'critical', 'alert', 'emergency']],
+            ['error', ['error', 'critical', 'alert', 'emergency']],
+            ['critical', ['critical', 'alert', 'emergency']],
+            ['alert', ['alert', 'emergency']],
+            ['emergency', ['emergency']],
+        ];
     }
 }


### PR DESCRIPTION
This PR updates the Nightwatch logger to respect the `LOG_LEVEL` environment variable, along with an additional `NIGHTWATCH_LOG_LEVEL` environment variable that will take priority if set.

If neither of these environment variables are set, Nightwatch will continue to log everything sent to the `nightwatch` log channel.