### PR TITLE
Redacting/scrubbing

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -196,6 +196,10 @@ trait CapturesState
             return;
         }
 
+        if ($this->redactOutgoingRequestCallback) {
+            $this->ignore(fn () => ($this->redactOutgoingRequestCallback)($record));
+        }
+
         $this->ingest->write($resolver());
     }
 
@@ -215,6 +219,10 @@ trait CapturesState
 
         if ($this->rejectQueryCallback && $this->ignore(fn () => ($this->rejectQueryCallback)($record))) {
             return;
+        }
+
+        if ($this->redactQueryCallback) {
+            $this->ignore(fn () => ($this->redactQueryCallback)($record));
         }
 
         $this->ingest->write($resolver());
@@ -289,6 +297,10 @@ trait CapturesState
             return;
         }
 
+        if ($this->redactMailCallback) {
+            $this->ignore(fn () => ($this->redactMailCallback)($record));
+        }
+
         $this->ingest->write($resolver());
     }
 
@@ -311,6 +323,10 @@ trait CapturesState
 
         if ($this->rejectCacheEventCallback && $this->ignore(fn () => ($this->rejectCacheEventCallback)($record))) {
             return;
+        }
+
+        if ($this->redactCacheEventCallback) {
+            $this->ignore(fn () => ($this->redactCacheEventCallback)($record));
         }
 
         $this->ingest->write($resolver());
@@ -361,7 +377,13 @@ trait CapturesState
      */
     public function request(Request $request, Response $response): void
     {
-        $this->ingest->write($this->sensor->request($request, $response));
+        [$record, $resolver] = $this->sensor->request($request, $response);
+
+        if ($this->redactRequestCallback) {
+            $this->ignore(fn () => ($this->redactRequestCallback)($record));
+        }
+
+        $this->ingest->write($resolver());
     }
 
     /**
@@ -490,7 +512,13 @@ trait CapturesState
      */
     public function command(InputInterface $input, int $status): void
     {
-        $this->ingest->write($this->sensor->command($input, $status));
+        [$record, $resolver] = $this->sensor->command($input, $status);
+
+        if ($this->redactCommandCallback) {
+            $this->ignore(fn () => ($this->redactCommandCallback)($record));
+        }
+
+        $this->ingest->write($resolver());
     }
 
     /**

--- a/src/Concerns/RedactsRecords.php
+++ b/src/Concerns/RedactsRecords.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Laravel\Nightwatch\Concerns;
+
+use Laravel\Nightwatch\Records\CacheEvent;
+use Laravel\Nightwatch\Records\Command;
+use Laravel\Nightwatch\Records\Mail;
+use Laravel\Nightwatch\Records\OutgoingRequest;
+use Laravel\Nightwatch\Records\Query;
+use Laravel\Nightwatch\Records\Request;
+
+trait RedactsRecords
+{
+    /**
+     * @var ?callable(CacheEvent): bool
+     */
+    private $redactCacheEventCallback = null;
+
+    /**
+     * @var ?callable(Command): bool
+     */
+    private $redactCommandCallback = null;
+
+    /**
+     * @var ?callable(Mail): bool
+     */
+    private $redactMailCallback = null;
+
+    /**
+     * @var ?callable(OutgoingRequest): bool
+     */
+    private $redactOutgoingRequestCallback = null;
+
+    /**
+     * @var ?callable(Query): bool
+     */
+    private $redactQueryCallback = null;
+
+    /**
+     * @var ?callable(Request): bool
+     */
+    private $redactRequestCallback = null;
+
+    /**
+     * @api
+     *
+     * @param  callable(CacheEvent): bool  $callback
+     */
+    public function redactCacheEvents(callable $callback): void
+    {
+        $this->redactCacheEventCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Command): bool  $callback
+     */
+    public function redactCommands(callable $callback): void
+    {
+        $this->redactCommandCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Mail): bool  $callback
+     */
+    public function redactMail(callable $callback): void
+    {
+        $this->redactMailCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(OutgoingRequest): bool  $callback
+     */
+    public function redactOutgoingRequests(callable $callback): void
+    {
+        $this->redactOutgoingRequestCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Query): bool  $callback
+     */
+    public function redactQueries(callable $callback): void
+    {
+        $this->redactQueryCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Request): bool  $callback
+     */
+    public function redactRequests(callable $callback): void
+    {
+        $this->redactRequestCallback = $callback;
+    }
+}

--- a/src/Core.php
+++ b/src/Core.php
@@ -17,6 +17,7 @@ use WeakMap;
 final class Core
 {
     use Concerns\CapturesState,
+        Concerns\RedactsRecords,
         Concerns\RejectsRecords;
 
     /**

--- a/src/Records/CacheEvent.php
+++ b/src/Records/CacheEvent.php
@@ -9,7 +9,7 @@ final class CacheEvent
      */
     public function __construct(
         public readonly string $store,
-        public readonly string $key,
+        public string $key,
         public readonly string $type,
         public readonly int $duration,
         public readonly int $ttl,

--- a/src/Records/Command.php
+++ b/src/Records/Command.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Nightwatch\Records;
+
+final class Command
+{
+    public function __construct(
+        public readonly string $class,
+        public readonly string $name,
+        public string $command,
+        public readonly int $exitCode,
+        public readonly int $duration,
+    ) {
+        //
+    }
+}

--- a/src/Records/Mail.php
+++ b/src/Records/Mail.php
@@ -7,7 +7,7 @@ final class Mail
     public function __construct(
         public readonly string $mailer,
         public readonly string $class,
-        public readonly string $subject,
+        public string $subject,
         public readonly int $to,
         public readonly int $cc,
         public readonly int $bcc,

--- a/src/Records/OutgoingRequest.php
+++ b/src/Records/OutgoingRequest.php
@@ -6,7 +6,7 @@ final class OutgoingRequest
 {
     public function __construct(
         public readonly string $method,
-        public readonly string $url,
+        public string $url,
         public readonly int $duration,
         public readonly int $requestSize,
         public readonly int $responseSize,

--- a/src/Records/Query.php
+++ b/src/Records/Query.php
@@ -5,7 +5,7 @@ namespace Laravel\Nightwatch\Records;
 final class Query
 {
     public function __construct(
-        public readonly string $sql,
+        public string $sql,
         public readonly string $file,
         public readonly int $line,
         public readonly int $duration,

--- a/src/Records/Request.php
+++ b/src/Records/Request.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Laravel\Nightwatch\Records;
+
+final class Request
+{
+    /**
+     * @param  array<string>  $routeMethods
+     */
+    public function __construct(
+        public readonly string $method,
+        public string $url,
+        public readonly string $routeName,
+        public readonly array $routeMethods,
+        public readonly string $routeDomain,
+        public readonly string $routePath,
+        public readonly string $routeAction,
+        public string $ip,
+        public readonly int $duration,
+        public readonly int $statusCode,
+        public readonly int $requestSize,
+        public readonly int $responseSize,
+    ) {
+        //
+    }
+}

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -19,11 +19,13 @@ use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Laravel\Nightwatch\Records\CacheEvent as CacheEventRecord;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Mail;
 use Laravel\Nightwatch\Records\Notification;
 use Laravel\Nightwatch\Records\OutgoingRequest;
 use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\Records\QueuedJob;
+use Laravel\Nightwatch\Records\Request as RequestRecord;
 use Laravel\Nightwatch\Sensors\CacheEventSensor;
 use Laravel\Nightwatch\Sensors\CommandSensor;
 use Laravel\Nightwatch\Sensors\ExceptionSensor;
@@ -113,12 +115,12 @@ final class SensorManager
     public $scheduledTaskSensor;
 
     /**
-     * @var (callable(Request, Response): array<mixed>)|null
+     * @var (callable(Request, Response): array{0: RequestRecord, 1: callable(): array<mixed>})|null
      */
     public $requestSensor;
 
     /**
-     * @var (callable(InputInterface, int): array<mixed>)|null
+     * @var (callable(InputInterface, int): array{0: Command, 1: callable(): array<mixed>})|null
      */
     public $commandSensor;
 
@@ -142,7 +144,7 @@ final class SensorManager
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: RequestRecord, 1: callable(): array<mixed>}
      */
     public function request(Request $request, Response $response): array
     {
@@ -154,7 +156,7 @@ final class SensorManager
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: Command, 1: callable(): array<mixed>}
      */
     public function command(InputInterface $input, int $status): array
     {

--- a/src/Sensors/CommandSensor.php
+++ b/src/Sensors/CommandSensor.php
@@ -4,6 +4,7 @@ namespace Laravel\Nightwatch\Sensors;
 
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\ExecutionStage;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\Types\Str;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -24,7 +25,7 @@ final class CommandSensor
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: Command, 1: callable(): array<mixed>}
      */
     public function __invoke(InputInterface $input, int $exitCode): array
     {
@@ -43,37 +44,48 @@ final class CommandSensor
         };
 
         return [
-            'v' => 1,
-            't' => 'command',
-            'timestamp' => $this->commandState->timestamp,
-            'deploy' => $this->commandState->deploy,
-            'server' => $this->commandState->server,
-            '_group' => hash('xxh128', $name),
-            'trace_id' => $this->commandState->trace,
-            // --- //
-            'class' => $class,
-            'name' => $name,
-            'command' => $command,
-            'exit_code' => $exitCode,
-            'duration' => array_sum($this->commandState->stageDurations),
-            // --- //
-            'bootstrap' => $this->commandState->stageDurations[ExecutionStage::Bootstrap->value],
-            'action' => $this->commandState->stageDurations[ExecutionStage::Action->value],
-            'terminating' => $this->commandState->stageDurations[ExecutionStage::Terminating->value],
-            'exceptions' => $this->commandState->exceptions,
-            'logs' => $this->commandState->logs,
-            'queries' => $this->commandState->queries,
-            'lazy_loads' => $this->commandState->lazyLoads,
-            'jobs_queued' => $this->commandState->jobsQueued,
-            'mail' => $this->commandState->mail,
-            'notifications' => $this->commandState->notifications,
-            'outgoing_requests' => $this->commandState->outgoingRequests,
-            'files_read' => $this->commandState->filesRead,
-            'files_written' => $this->commandState->filesWritten,
-            'cache_events' => $this->commandState->cacheEvents,
-            'hydrated_models' => $this->commandState->hydratedModels,
-            'peak_memory_usage' => $this->commandState->peakMemory(),
-            'exception_preview' => Str::tinyText($this->commandState->exceptionPreview),
+            $record = new Command(
+                class: $class,
+                name: $name,
+                command: $command,
+                exitCode: $exitCode,
+                duration: array_sum($this->commandState->stageDurations),
+            ),
+            function () use ($record) {
+                return [
+                    'v' => 1,
+                    't' => 'command',
+                    'timestamp' => $this->commandState->timestamp,
+                    'deploy' => $this->commandState->deploy,
+                    'server' => $this->commandState->server,
+                    '_group' => hash('xxh128', $record->name),
+                    'trace_id' => $this->commandState->trace,
+                    // --- //
+                    'class' => $record->class,
+                    'name' => $record->name,
+                    'command' => $record->command,
+                    'exit_code' => $record->exitCode,
+                    'duration' => $record->duration,
+                    // --- //
+                    'bootstrap' => $this->commandState->stageDurations[ExecutionStage::Bootstrap->value],
+                    'action' => $this->commandState->stageDurations[ExecutionStage::Action->value],
+                    'terminating' => $this->commandState->stageDurations[ExecutionStage::Terminating->value],
+                    'exceptions' => $this->commandState->exceptions,
+                    'logs' => $this->commandState->logs,
+                    'queries' => $this->commandState->queries,
+                    'lazy_loads' => $this->commandState->lazyLoads,
+                    'jobs_queued' => $this->commandState->jobsQueued,
+                    'mail' => $this->commandState->mail,
+                    'notifications' => $this->commandState->notifications,
+                    'outgoing_requests' => $this->commandState->outgoingRequests,
+                    'files_read' => $this->commandState->filesRead,
+                    'files_written' => $this->commandState->filesWritten,
+                    'cache_events' => $this->commandState->cacheEvents,
+                    'hydrated_models' => $this->commandState->hydratedModels,
+                    'peak_memory_usage' => $this->commandState->peakMemory(),
+                    'exception_preview' => Str::tinyText($this->commandState->exceptionPreview),
+                ];
+            },
         ];
     }
 }

--- a/src/Sensors/RequestSensor.php
+++ b/src/Sensors/RequestSensor.php
@@ -5,6 +5,7 @@ namespace Laravel\Nightwatch\Sensors;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Route;
 use Laravel\Nightwatch\ExecutionStage;
+use Laravel\Nightwatch\Records\Request as RequestRecord;
 use Laravel\Nightwatch\State\RequestState;
 use Laravel\Nightwatch\Types\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -33,7 +34,7 @@ final class RequestSensor
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: RequestRecord, 1: callable(): array<mixed>}
      */
     public function __invoke(Request $request, Response $response): array
     {
@@ -62,49 +63,67 @@ final class RequestSensor
         }
 
         return [
-            'v' => 1,
-            't' => 'request',
-            'timestamp' => $this->requestState->timestamp,
-            'deploy' => $this->requestState->deploy,
-            'server' => $this->requestState->server,
-            '_group' => hash('xxh128', implode('|', $routeMethods).",{$routeDomain},{$routePath}"),
-            'trace_id' => $this->requestState->trace,
-            'user' => $this->requestState->user->id(),
-            // --- //
-            'method' => $request->getMethod(),
-            'url' => $request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(strlen($query) > 0 ? "?{$query}" : ''),
-            'route_name' => $route?->getName() ?? '',
-            'route_methods' => $routeMethods,
-            'route_domain' => $routeDomain,
-            'route_path' => $routePath,
-            'route_action' => $route?->getActionName() ?? '',
-            'ip' => $request->ip() ?? '',
-            'duration' => array_sum($this->requestState->stageDurations),
-            'status_code' => $response->getStatusCode(),
-            'request_size' => strlen($request->getContent()),
-            'response_size' => $this->parseResponseSize($response),
-            // --- //
-            'bootstrap' => $this->requestState->stageDurations[ExecutionStage::Bootstrap->value],
-            'before_middleware' => $this->requestState->stageDurations[ExecutionStage::BeforeMiddleware->value],
-            'action' => $this->requestState->stageDurations[ExecutionStage::Action->value],
-            'render' => $this->requestState->stageDurations[ExecutionStage::Render->value],
-            'after_middleware' => $this->requestState->stageDurations[ExecutionStage::AfterMiddleware->value],
-            'sending' => $this->requestState->stageDurations[ExecutionStage::Sending->value],
-            'terminating' => $this->requestState->stageDurations[ExecutionStage::Terminating->value],
-            'exceptions' => $this->requestState->exceptions,
-            'logs' => $this->requestState->logs,
-            'queries' => $this->requestState->queries,
-            'lazy_loads' => $this->requestState->lazyLoads,
-            'jobs_queued' => $this->requestState->jobsQueued,
-            'mail' => $this->requestState->mail,
-            'notifications' => $this->requestState->notifications,
-            'outgoing_requests' => $this->requestState->outgoingRequests,
-            'files_read' => $this->requestState->filesRead,
-            'files_written' => $this->requestState->filesWritten,
-            'cache_events' => $this->requestState->cacheEvents,
-            'hydrated_models' => $this->requestState->hydratedModels,
-            'peak_memory_usage' => $this->requestState->peakMemory(),
-            'exception_preview' => Str::tinyText($this->requestState->exceptionPreview),
+            $record = new RequestRecord(
+                method: $request->getMethod(),
+                url: $request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(strlen($query) > 0 ? "?{$query}" : ''),
+                routeName: $route?->getName() ?? '',
+                routeMethods: $routeMethods,
+                routeDomain: $routeDomain,
+                routePath: $routePath,
+                routeAction: $route?->getActionName() ?? '',
+                ip: $request->ip() ?? '',
+                duration: array_sum($this->requestState->stageDurations),
+                statusCode: $response->getStatusCode(),
+                requestSize: strlen($request->getContent()),
+                responseSize: $this->parseResponseSize($response),
+            ),
+            function () use ($record) {
+                return [
+                    'v' => 1,
+                    't' => 'request',
+                    'timestamp' => $this->requestState->timestamp,
+                    'deploy' => $this->requestState->deploy,
+                    'server' => $this->requestState->server,
+                    '_group' => hash('xxh128', implode('|', $record->routeMethods).",{$record->routeDomain},{$record->routePath}"),
+                    'trace_id' => $this->requestState->trace,
+                    'user' => $this->requestState->user->id(),
+                    // --- //
+                    'method' => $record->method,
+                    'url' => $record->url,
+                    'route_name' => $record->routeName,
+                    'route_methods' => $record->routeMethods,
+                    'route_domain' => $record->routeDomain,
+                    'route_path' => $record->routePath,
+                    'route_action' => $record->routeAction,
+                    'ip' => $record->ip,
+                    'duration' => $record->duration,
+                    'status_code' => $record->statusCode,
+                    'request_size' => $record->requestSize,
+                    'response_size' => $record->responseSize,
+                    // --- //
+                    'bootstrap' => $this->requestState->stageDurations[ExecutionStage::Bootstrap->value],
+                    'before_middleware' => $this->requestState->stageDurations[ExecutionStage::BeforeMiddleware->value],
+                    'action' => $this->requestState->stageDurations[ExecutionStage::Action->value],
+                    'render' => $this->requestState->stageDurations[ExecutionStage::Render->value],
+                    'after_middleware' => $this->requestState->stageDurations[ExecutionStage::AfterMiddleware->value],
+                    'sending' => $this->requestState->stageDurations[ExecutionStage::Sending->value],
+                    'terminating' => $this->requestState->stageDurations[ExecutionStage::Terminating->value],
+                    'exceptions' => $this->requestState->exceptions,
+                    'logs' => $this->requestState->logs,
+                    'queries' => $this->requestState->queries,
+                    'lazy_loads' => $this->requestState->lazyLoads,
+                    'jobs_queued' => $this->requestState->jobsQueued,
+                    'mail' => $this->requestState->mail,
+                    'notifications' => $this->requestState->notifications,
+                    'outgoing_requests' => $this->requestState->outgoingRequests,
+                    'files_read' => $this->requestState->filesRead,
+                    'files_written' => $this->requestState->filesWritten,
+                    'cache_events' => $this->requestState->cacheEvents,
+                    'hydrated_models' => $this->requestState->hydratedModels,
+                    'peak_memory_usage' => $this->requestState->peakMemory(),
+                    'exception_preview' => Str::tinyText($this->requestState->exceptionPreview),
+                ];
+            },
         ];
     }
 

--- a/tests/Feature/Sensors/RequestSensorTest.php
+++ b/tests/Feature/Sensors/RequestSensorTest.php
@@ -138,7 +138,8 @@ class RequestSensorTest extends TestCase
         $response = response()->file(stream_get_meta_data($file)['uri'])->deleteFileAfterSend()->sendContent();
         ob_end_clean();
 
-        $this->core->ingest->write($this->core->sensor->request($request, $response));
+        [$record, $resolver] = $this->core->sensor->request($request, $response);
+        $this->core->ingest->write($resolver());
         $ingest->digest();
 
         $ingest->assertLatestWrite('request:0.response_size', 0);
@@ -182,7 +183,8 @@ class RequestSensorTest extends TestCase
         $response = response()->file(stream_get_meta_data($file)['uri'], headers: ['Content-length' => 17])->deleteFileAfterSend()->sendContent();
         ob_end_clean();
 
-        $this->core->ingest->write($this->core->sensor->request($request, $response));
+        [$record, $resolver] = $this->core->sensor->request($request, $response);
+        $this->core->ingest->write($resolver());
         $ingest->digest();
 
         $ingest->assertWrittenTimes(1);

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -6,6 +6,8 @@ use App\Jobs\MyJob;
 use App\Jobs\SampledJob;
 use App\Mail\MyMail;
 use App\Notifications\MyNotification;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -16,17 +18,22 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\CacheEvent;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Mail as MailRecord;
 use Laravel\Nightwatch\Records\Notification as NotificationRecord;
 use Laravel\Nightwatch\Records\OutgoingRequest;
 use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\Records\QueuedJob;
+use Laravel\Nightwatch\Records\Request;
 use RuntimeException;
+use Symfony\Component\Console\Input\StringInput;
 use Tests\TestCase;
 
 use function array_shift;
+use function preg_replace;
 use function report;
 use function str_contains;
+use function str_replace;
 
 class FilteringTest extends TestCase
 {
@@ -423,5 +430,103 @@ class FilteringTest extends TestCase
             $this->assertStringContainsString('"nightwatch_should_sample":false', $second);
             $this->assertStringContainsString('"nightwatch_should_sample":true', $third);
         }
+    }
+
+    public function test_it_can_redact_cache_events(): void
+    {
+        $ingest = $this->fakeIngest();
+        Nightwatch::redactCacheEvents(function (CacheEvent $cacheEvent) {
+            $cacheEvent->key = str_replace('jess@laravel.com|127.0.0.1', '***@***|*.*.*.*', $cacheEvent->key);
+        });
+
+        Cache::get('jess@laravel.com|127.0.0.1');
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('cache-event:0.key', '***@***|*.*.*.*');
+    }
+
+    public function test_it_can_redact_commands(): void
+    {
+        $this->forceCommandExecutionState();
+        $this->refreshApplication();
+        parent::setUp();
+        $this->app[ConsoleKernel::class]->rerouteSymfonyCommandEvents();
+        $ingest = $this->fakeIngest();
+        Nightwatch::redactCommands(function (Command $command) {
+            $command->command = str_replace('jess@laravel.com', '***@***', $command->command);
+        });
+        Artisan::command('mail:send {--email=}', fn () => 0);
+
+        $status = Artisan::handle($input = new StringInput('mail:send --email=jess@laravel.com'));
+        Artisan::terminate($input, $status);
+
+        $this->assertSame(0, $status);
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('command:0.command', 'mail:send --email=***@***');
+    }
+
+    public function test_it_can_redact_mail(): void
+    {
+        $ingest = $this->fakeIngest();
+        Nightwatch::redactMail(function (MailRecord $mail) {
+            $mail->subject = str_replace('Jess', '****', $mail->subject);
+        });
+
+        Mail::to('jess@laravel.com')->send(new MyMail('Hello Jess'));
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('mail:0.subject', 'Hello ****');
+    }
+
+    public function test_it_can_redact_outgoing_requests(): void
+    {
+        $ingest = $this->fakeIngest();
+        Http::fake([
+            'https://api.example.com/user?email=jess@laravel.com' => Http::response(status: 200),
+        ]);
+        Nightwatch::redactOutgoingRequests(function (OutgoingRequest $outgoingRequest) {
+            $outgoingRequest->url = str_replace('jess@laravel.com', '***@***', $outgoingRequest->url);
+        });
+
+        Http::get('https://api.example.com/user?email=jess@laravel.com');
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('outgoing-request:0.url', 'https://api.example.com/user?email=***@***');
+    }
+
+    public function test_it_can_redact_queries(): void
+    {
+        $ingest = $this->fakeIngest();
+        Nightwatch::redactQueries(function (Query $query) {
+            $query->sql = str_replace('jess@laravel.com', '***@***', $query->sql);
+        });
+
+        DB::statement('select * from users where email = "jess@laravel.com"');
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.sql', 'select * from users where email = "***@***"');
+    }
+
+    public function test_it_can_redact_requests(): void
+    {
+        $ingest = $this->fakeIngest();
+        Nightwatch::redactRequests(function (Request $request) {
+            $request->url = str_replace('jess@laravel.com', '***@***', $request->url);
+            $request->url = str_replace('secret', '***', $request->url);
+            $request->ip = preg_replace('/\d{1,3}\.\d{1,3}$/', '*.*', $request->ip);
+        });
+        Route::get('/test/{email}', function () {
+            return 'ok';
+        });
+
+        $this->get('/test/jess@laravel.com?token=secret');
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('request:0.url', 'http://localhost/test/***@***?token=***');
+        $ingest->assertLatestWrite('request:0.ip', '127.0.*.*');
     }
 }


### PR DESCRIPTION
This PR adds support for redacting/scrubbing several fields that could contain sensitive data.

```php
// AppServiceProvider.php

use Laravel\Nightwatch\Facades\Nightwatch;
use Laravel\Nightwatch\Records\CacheEvent;
use Laravel\Nightwatch\Records\Command;
use Laravel\Nightwatch\Records\Mail;
use Laravel\Nightwatch\Records\OutgoingRequest;
use Laravel\Nightwatch\Records\Query;
use Laravel\Nightwatch\Records\Request;

Nightwatch::redactCacheEvents(function (CacheEvent $cacheEvent) {
    $cacheEvent->key = str_replace('secret', '***', $cacheEvent->key);
});

Nightwatch::redactCommands(function (Command $command) {
    $command->command = str_replace('secret', '***', $command->command);
});

Nightwatch::redactMail(function (Mail $mail) {
    $mail->subject = str_replace('secret', '***', $mail->subject);
});

Nightwatch::redactOutgoingRequests(function (OutgoingRequest $outgoingRequest) {
    $outgoingRequest->url = str_replace('secret', '***', $outgoingRequest->url);
});

Nightwatch::redactQueries(function (Query $query) {
    $query->sql = str_replace('secret', '***', $query->sql);
});

Nightwatch::redactRequests(function (Request $request) {
    $request->url = str_replace('secret', '***', $request->url);
    $request->ip = str_replace('secret', '***', $request->ip);
});
```