### PR TITLE
Remove internal API from facade

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -534,6 +534,9 @@ trait CapturesState
         }
     }
 
+    /**
+     * @internal
+     */
     public function prepareForNextRequest(): void
     {
         /** @var Core<RequestState> $this */


### PR DESCRIPTION
This API is currently listed on the Facade. It is an internal API. This will remove it from the documented methods.