### PR TITLE
fix: change UserProvider to Singleton in NightwatchServiceProvider.php

### DIFF
--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -462,11 +462,13 @@ final class NightwatchServiceProvider extends ServiceProvider
             /** @var AuthManager */
             $auth = $this->app->make(AuthManager::class);
 
-            /** @var UserProvider */
-            $userProvider = $this->app->singleton(
+            $this->app->singleton(
                 UserProvider::class,
                 fn () => new UserProvider($auth, fn () => $this->core->userDetailsResolver)
             );
+
+            /** @var UserProvider */
+            $userProvider = $this->app->make(UserProvider::class,);
 
             return new RequestState(
                 timestamp: $this->timestamp,

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -461,6 +461,10 @@ final class NightwatchServiceProvider extends ServiceProvider
         if ($this->isRequest) {
             /** @var AuthManager */
             $auth = $this->app->make(AuthManager::class);
+            $userProvider = $this->app->singleton(
+                UserProvider::class,
+                fn () => new UserProvider($auth, fn () => $this->core->userDetailsResolver)
+            );
 
             return new RequestState(
                 timestamp: $this->timestamp,
@@ -469,7 +473,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                 currentExecutionStageStartedAtMicrotime: $this->timestamp,
                 deploy: $this->nightwatchConfig['deployment'] ?? '',
                 server: $this->nightwatchConfig['server'] ?? '',
-                user: $this->app->singleton(UserProvider::class, fn () => new UserProvider($auth, fn () => $this->core->userDetailsResolver)),
+                user: $userProvider,
             );
         } else {
             return new CommandState(

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -469,7 +469,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                 currentExecutionStageStartedAtMicrotime: $this->timestamp,
                 deploy: $this->nightwatchConfig['deployment'] ?? '',
                 server: $this->nightwatchConfig['server'] ?? '',
-                user: new UserProvider($auth, fn () => $this->core->userDetailsResolver),
+                user: $this->app->singleton(UserProvider::class, fn () => new UserProvider($auth, fn () => $this->core->userDetailsResolver)),
             );
         } else {
             return new CommandState(

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -461,6 +461,8 @@ final class NightwatchServiceProvider extends ServiceProvider
         if ($this->isRequest) {
             /** @var AuthManager */
             $auth = $this->app->make(AuthManager::class);
+
+            /** @var UserProvider */
             $userProvider = $this->app->singleton(
                 UserProvider::class,
                 fn () => new UserProvider($auth, fn () => $this->core->userDetailsResolver)

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -468,7 +468,7 @@ final class NightwatchServiceProvider extends ServiceProvider
             );
 
             /** @var UserProvider */
-            $userProvider = $this->app->make(UserProvider::class,);
+            $userProvider = $this->app->make(UserProvider::class);
 
             return new RequestState(
                 timestamp: $this->timestamp,


### PR DESCRIPTION
We use Keycloak authorization in our application, and after installing the Nightwatch package, the application crashed due to thousands of authorization requests.
Couldn't a singleton be used in this function?

Before:
![image](https://github.com/user-attachments/assets/74c96a1a-d8fa-458a-8dab-7f4d8493d36e)

After:
![image](https://github.com/user-attachments/assets/944b3491-30d3-476c-ad04-688e1eade361)
