### PR TITLE
feat: implement `Nightwatch::rejectCommands()`

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -490,7 +490,13 @@ trait CapturesState
      */
     public function command(InputInterface $input, int $status): void
     {
-        $this->ingest->write($this->sensor->command($input, $status));
+        [$record, $resolver] = $this->sensor->command($input, $status);
+
+        if ($this->rejectCommandCallback && $this->ignore(fn () => ($this->rejectCommandCallback)($record))) {
+            return;
+        }
+
+        $this->ingest->write($resolver());
     }
 
     /**

--- a/src/Concerns/RejectsRecords.php
+++ b/src/Concerns/RejectsRecords.php
@@ -18,6 +18,11 @@ trait RejectsRecords
     private $rejectCacheEventCallback = null;
 
     /**
+     * @var ?callable(Command): bool
+     */
+    private $rejectCommandCallback = null;
+
+    /**
      * @var ?callable(Mail): bool
      */
     private $rejectMailCallback = null;
@@ -43,11 +48,6 @@ trait RejectsRecords
     private $rejectQueuedJobCallback = null;
 
     /**
-     * @var ?callable(Command): bool
-     */
-    private $rejectCommandCallback = null;
-
-    /**
      * @api
      *
      * @param  callable(CacheEvent): bool  $callback
@@ -55,6 +55,16 @@ trait RejectsRecords
     public function rejectCacheEvents(callable $callback): void
     {
         $this->rejectCacheEventCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Command): bool  $callback
+     */
+    public function rejectCommands(callable $callback): void
+    {
+        $this->rejectCommandCallback = $callback;
     }
 
     /**
@@ -105,15 +115,5 @@ trait RejectsRecords
     public function rejectQueuedJobs(callable $callback): void
     {
         $this->rejectQueuedJobCallback = $callback;
-    }
-
-    /**
-     * @api
-     *
-     * @param  callable(Command): bool  $callback
-     */
-    public function rejectCommands(callable $callback): void
-    {
-        $this->rejectCommandCallback = $callback;
     }
 }

--- a/src/Concerns/RejectsRecords.php
+++ b/src/Concerns/RejectsRecords.php
@@ -3,6 +3,7 @@
 namespace Laravel\Nightwatch\Concerns;
 
 use Laravel\Nightwatch\Records\CacheEvent;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Mail;
 use Laravel\Nightwatch\Records\Notification;
 use Laravel\Nightwatch\Records\OutgoingRequest;
@@ -40,6 +41,11 @@ trait RejectsRecords
      * @var ?callable(QueuedJob): bool
      */
     private $rejectQueuedJobCallback = null;
+
+    /**
+     * @var ?callable(Command): bool
+     */
+    private $rejectCommandCallback = null;
 
     /**
      * @api
@@ -99,5 +105,15 @@ trait RejectsRecords
     public function rejectQueuedJobs(callable $callback): void
     {
         $this->rejectQueuedJobCallback = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Command): bool  $callback
+     */
+    public function rejectCommands(callable $callback): void
+    {
+        $this->rejectCommandCallback = $callback;
     }
 }

--- a/src/Facades/Nightwatch.php
+++ b/src/Facades/Nightwatch.php
@@ -24,6 +24,7 @@ use function call_user_func;
  * @method static void rejectOutgoingRequests(callable $callback)
  * @method static void rejectQueries(callable $callback)
  * @method static void rejectQueuedJobs(callable $callback)
+ * @method static void rejectCommands(callable $callback)
  *
  * @see \Laravel\Nightwatch\Core
  */

--- a/src/Records/Command.php
+++ b/src/Records/Command.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Laravel\Nightwatch\Records;
+
+final class Command
+{
+    public function __construct(
+        public readonly string $class,
+        public readonly string $name,
+        public readonly string $command,
+        public readonly int $exitCode,
+        public readonly int $duration,
+    ) {
+        //
+    }
+}

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -19,6 +19,7 @@ use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Laravel\Nightwatch\Records\CacheEvent as CacheEventRecord;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Mail;
 use Laravel\Nightwatch\Records\Notification;
 use Laravel\Nightwatch\Records\OutgoingRequest;
@@ -118,7 +119,7 @@ final class SensorManager
     public $requestSensor;
 
     /**
-     * @var (callable(InputInterface, int): array<mixed>)|null
+     * @var (callable(InputInterface, int): array{0: Command, 1: callable(): array<mixed>})|null
      */
     public $commandSensor;
 
@@ -154,7 +155,7 @@ final class SensorManager
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: Command, 1: callable(): array<mixed>}
      */
     public function command(InputInterface $input, int $status): array
     {

--- a/src/Sensors/CommandSensor.php
+++ b/src/Sensors/CommandSensor.php
@@ -4,6 +4,7 @@ namespace Laravel\Nightwatch\Sensors;
 
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\ExecutionStage;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\Types\Str;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -24,7 +25,7 @@ final class CommandSensor
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: Command, 1: callable(): array<mixed>}
      */
     public function __invoke(InputInterface $input, int $exitCode): array
     {
@@ -42,38 +43,51 @@ final class CommandSensor
             default => (string) $input,
         };
 
+        $duration = array_sum($this->commandState->stageDurations);
+
         return [
-            'v' => 1,
-            't' => 'command',
-            'timestamp' => $this->commandState->timestamp,
-            'deploy' => $this->commandState->deploy,
-            'server' => $this->commandState->server,
-            '_group' => hash('xxh128', $name),
-            'trace_id' => $this->commandState->trace,
-            // --- //
-            'class' => $class,
-            'name' => $name,
-            'command' => $command,
-            'exit_code' => $exitCode,
-            'duration' => array_sum($this->commandState->stageDurations),
-            // --- //
-            'bootstrap' => $this->commandState->stageDurations[ExecutionStage::Bootstrap->value],
-            'action' => $this->commandState->stageDurations[ExecutionStage::Action->value],
-            'terminating' => $this->commandState->stageDurations[ExecutionStage::Terminating->value],
-            'exceptions' => $this->commandState->exceptions,
-            'logs' => $this->commandState->logs,
-            'queries' => $this->commandState->queries,
-            'lazy_loads' => $this->commandState->lazyLoads,
-            'jobs_queued' => $this->commandState->jobsQueued,
-            'mail' => $this->commandState->mail,
-            'notifications' => $this->commandState->notifications,
-            'outgoing_requests' => $this->commandState->outgoingRequests,
-            'files_read' => $this->commandState->filesRead,
-            'files_written' => $this->commandState->filesWritten,
-            'cache_events' => $this->commandState->cacheEvents,
-            'hydrated_models' => $this->commandState->hydratedModels,
-            'peak_memory_usage' => $this->commandState->peakMemory(),
-            'exception_preview' => Str::tinyText($this->commandState->exceptionPreview),
+            $record = new Command(
+                class: $class,
+                name: $name,
+                command: $command,
+                exitCode: $exitCode,
+                duration: $duration,
+            ),
+            function () use ($record): array {
+                return [
+                    'v' => 1,
+                    't' => 'command',
+                    'timestamp' => $this->commandState->timestamp,
+                    'deploy' => $this->commandState->deploy,
+                    'server' => $this->commandState->server,
+                    '_group' => hash('xxh128', $record->name),
+                    'trace_id' => $this->commandState->trace,
+                    // --- //
+                    'class' => $record->class,
+                    'name' => $record->name,
+                    'command' => $record->command,
+                    'exit_code' => $record->exitCode,
+                    'duration' => $record->duration,
+                    // --- //
+                    'bootstrap' => $this->commandState->stageDurations[ExecutionStage::Bootstrap->value],
+                    'action' => $this->commandState->stageDurations[ExecutionStage::Action->value],
+                    'terminating' => $this->commandState->stageDurations[ExecutionStage::Terminating->value],
+                    'exceptions' => $this->commandState->exceptions,
+                    'logs' => $this->commandState->logs,
+                    'queries' => $this->commandState->queries,
+                    'lazy_loads' => $this->commandState->lazyLoads,
+                    'jobs_queued' => $this->commandState->jobsQueued,
+                    'mail' => $this->commandState->mail,
+                    'notifications' => $this->commandState->notifications,
+                    'outgoing_requests' => $this->commandState->outgoingRequests,
+                    'files_read' => $this->commandState->filesRead,
+                    'files_written' => $this->commandState->filesWritten,
+                    'cache_events' => $this->commandState->cacheEvents,
+                    'hydrated_models' => $this->commandState->hydratedModels,
+                    'peak_memory_usage' => $this->commandState->peakMemory(),
+                    'exception_preview' => Str::tinyText($this->commandState->exceptionPreview),
+                ];
+            }
         ];
     }
 }

--- a/src/Sensors/CommandSensor.php
+++ b/src/Sensors/CommandSensor.php
@@ -43,15 +43,13 @@ final class CommandSensor
             default => (string) $input,
         };
 
-        $duration = array_sum($this->commandState->stageDurations);
-
         return [
             $record = new Command(
                 class: $class,
                 name: $name,
                 command: $command,
                 exitCode: $exitCode,
-                duration: $duration,
+                duration: array_sum($this->commandState->stageDurations),
             ),
             function () use ($record): array {
                 return [

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\CacheEvent;
+use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Mail as MailRecord;
 use Laravel\Nightwatch\Records\Notification as NotificationRecord;
 use Laravel\Nightwatch\Records\OutgoingRequest;
@@ -282,6 +283,29 @@ class FilteringTest extends TestCase
         $ingest->assertLatestWrite('queued-job:0.name', SampledJob::class);
     }
 
+    public function test_it_can_filter_commands(): void
+    {
+        $this->forceCommandExecutionState();
+        $ingest = $this->fakeIngest();
+        
+        Nightwatch::rejectCommands(function (Command $command) {
+            return str_contains($command->name, 'migrate');
+        });
+
+        // Simulate running commands
+        $this->artisan('help');
+        $this->artisan('migrate:status');
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite(function ($records) {
+            $this->assertCount(1, $records);
+
+            return true;
+        });
+        $ingest->assertLatestWrite('command:0.name', 'help');
+    }
+
     public function test_it_does_not_trigger_recursion_while_filtering()
     {
         $ingest = $this->fakeIngest();
@@ -318,6 +342,11 @@ class FilteringTest extends TestCase
 
             return true;
         });
+        Nightwatch::rejectCommands(function (Command $command) {
+            $this->artisan('help');
+
+            return true;
+        });
 
         DB::statement('select * from users');
         MyJob::dispatch();
@@ -325,6 +354,7 @@ class FilteringTest extends TestCase
         Mail::to('tim@laravel.com')->send(new MyMail('Hello Laravel'));
         Cache::get('keep');
         Http::get('https://nightwatch.laravel.com');
+        $this->artisan('help');
         $ingest->digest();
 
         $ingest->assertWrittenTimes(0);


### PR DESCRIPTION
This PR implements a `Nightwatch::rejectCommands()` method, to e.g. filter out `health:` tasks.

Thanks!