### PR TITLE
Fix sampling at zero with Nova

### DIFF
--- a/src/Http/Middleware/Sample.php
+++ b/src/Http/Middleware/Sample.php
@@ -19,7 +19,7 @@ class Sample
         //
     }
 
-    public static function rate($rate): string
+    public static function rate(float $rate): string
     {
         $rate = (string) $rate;
 

--- a/src/Http/Middleware/Sample.php
+++ b/src/Http/Middleware/Sample.php
@@ -19,8 +19,14 @@ class Sample
         //
     }
 
-    public static function rate(float $rate): string
+    public static function rate($rate): string
     {
+        $rate = (string) $rate;
+
+        if ($rate === '0') {
+            $rate = '0.0';
+        }
+
         return static::class.':'.$rate;
     }
 

--- a/tests/Feature/Http/Middleware/SampleTest.php
+++ b/tests/Feature/Http/Middleware/SampleTest.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Http\Middleware\Sample;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class SampleTest extends TestCase
@@ -112,5 +113,24 @@ class SampleTest extends TestCase
         $response = $this->get('/sampled-or-throw');
 
         $response->assertOk();
+    }
+
+    #[DataProvider('sampleRates')]
+    public function test_it_can_sample_at_different_rates(float|int $rate, string $expected): void
+    {
+        $this->assertSame(Sample::rate($rate), $expected);
+    }
+
+    public static function sampleRates(): iterable
+    {
+        yield [1, 'Laravel\Nightwatch\Http\Middleware\Sample:1'];
+        yield [1.0, 'Laravel\Nightwatch\Http\Middleware\Sample:1'];
+        yield [0.9999, 'Laravel\Nightwatch\Http\Middleware\Sample:0.9999'];
+        yield [0.0, 'Laravel\Nightwatch\Http\Middleware\Sample:0'];
+        yield [0.5, 'Laravel\Nightwatch\Http\Middleware\Sample:0.5'];
+        yield [0.001, 'Laravel\Nightwatch\Http\Middleware\Sample:0.001'];
+        yield [0.001, 'Laravel\Nightwatch\Http\Middleware\Sample:0.001'];
+        yield [0, 'Laravel\Nightwatch\Http\Middleware\Sample:0'];
+        yield [0.0, 'Laravel\Nightwatch\Http\Middleware\Sample:0'];
     }
 }

--- a/tests/Feature/Http/Middleware/SampleTest.php
+++ b/tests/Feature/Http/Middleware/SampleTest.php
@@ -126,11 +126,9 @@ class SampleTest extends TestCase
         yield [1, 'Laravel\Nightwatch\Http\Middleware\Sample:1'];
         yield [1.0, 'Laravel\Nightwatch\Http\Middleware\Sample:1'];
         yield [0.9999, 'Laravel\Nightwatch\Http\Middleware\Sample:0.9999'];
-        yield [0.0, 'Laravel\Nightwatch\Http\Middleware\Sample:0'];
         yield [0.5, 'Laravel\Nightwatch\Http\Middleware\Sample:0.5'];
         yield [0.001, 'Laravel\Nightwatch\Http\Middleware\Sample:0.001'];
-        yield [0.001, 'Laravel\Nightwatch\Http\Middleware\Sample:0.001'];
-        yield [0, 'Laravel\Nightwatch\Http\Middleware\Sample:0'];
-        yield [0.0, 'Laravel\Nightwatch\Http\Middleware\Sample:0'];
+        yield [0, 'Laravel\Nightwatch\Http\Middleware\Sample:0.0'];
+        yield [0.0, 'Laravel\Nightwatch\Http\Middleware\Sample:0.0'];
     }
 }


### PR DESCRIPTION
In certain scenarios, using a sample rate of `0` ends up with a 500 error due to Laravel's parsing of middleware arguments which seems to drop the `0` value, causing a failure when calling the `handle` method.

I considered making the `rate` optional in the `handle` method, but would rather leave it until we know that is necessary.