### PR TITLE
Implement ignoring for queued jobs

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -18,6 +18,7 @@ return [
         'ignore_notifications' => env('NIGHTWATCH_IGNORE_NOTIFICATIONS', false),
         'ignore_outgoing_requests' => env('NIGHTWATCH_IGNORE_OUTGOING_REQUESTS', false),
         'ignore_queries' => env('NIGHTWATCH_IGNORE_QUERIES', false),
+        'ignore_queued_jobs' => env('NIGHTWATCH_IGNORE_QUEUED_JOBS', false),
         'log_level' => env('NIGHTWATCH_LOG_LEVEL', env('LOG_LEVEL', 'debug')),
     ],
 

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -232,7 +232,7 @@ trait CapturesState
      */
     public function queuedJob(JobQueueing|JobQueued $event): void
     {
-        if ($this->paused) {
+        if ($this->config['filtering']['ignore_queued_jobs'] || $this->paused) {
             return;
         }
 

--- a/src/Core.php
+++ b/src/Core.php
@@ -42,6 +42,7 @@ final class Core
      *         ignore_notifications: bool,
      *         ignore_outgoing_requests: bool,
      *         ignore_queries: bool,
+     *         ignore_queued_jobs: bool,
      *     },
      * }  $config
      */

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -251,6 +251,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                     'ignore_notifications' => (bool) ($this->nightwatchConfig['filtering']['ignore_notifications'] ?? false),
                     'ignore_outgoing_requests' => (bool) ($this->nightwatchConfig['filtering']['ignore_outgoing_requests'] ?? false),
                     'ignore_queries' => (bool) ($this->nightwatchConfig['filtering']['ignore_queries'] ?? false),
+                    'ignore_queued_jobs' => (bool) ($this->nightwatchConfig['filtering']['ignore_queued_jobs'] ?? false),
                 ],
             ],
         ));

--- a/tests/FakeJob.php
+++ b/tests/FakeJob.php
@@ -3,6 +3,7 @@
 namespace Tests;
 
 use Illuminate\Contracts\Queue\Job as JobContract;
+use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Support\Str;
 
@@ -10,6 +11,10 @@ use function once;
 
 class FakeJob extends Job implements JobContract
 {
+    use Dispatchable;
+
+    public function handle(): void {}
+
     /**
      * Get the job identifier.
      *

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -6,10 +6,12 @@ use App\Jobs\MyJob;
 use App\Jobs\SampledJob;
 use App\Mail\MyMail;
 use App\Notifications\MyNotification;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Mail;
@@ -26,7 +28,10 @@ use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\Records\QueuedJob;
 use Laravel\Nightwatch\Records\Request;
 use RuntimeException;
+use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Tests\FakeJob;
 use Tests\TestCase;
 
 use function array_shift;
@@ -81,6 +86,27 @@ class FilteringTest extends TestCase
             return true;
         });
         $ingest->assertLatestWrite('query:0.sql', 'select * from users');
+    }
+
+    public function test_it_can_ignore_queued_jobs(): void
+    {
+        Event::dispatch(new CommandStarting('queue:work', new ArgvInput, new NullOutput));
+
+        $this->core->config['filtering']['ignore_queued_jobs'] = true;
+
+        for ($i = 0; $i < 10; $i++) {
+            FakeJob::dispatch();
+        }
+
+        $this->assertSame(0, $this->core->executionState->jobsQueued);
+
+        $this->core->config['filtering']['ignore_queued_jobs'] = false;
+
+        for ($i = 0; $i < 10; $i++) {
+            FakeJob::dispatch();
+        }
+
+        $this->assertSame(10, $this->core->executionState->jobsQueued);
     }
 
     public function test_it_records_queries_when_null_is_returned(): void


### PR DESCRIPTION
This pull request introduces a new configuration option, `ignore_queued_jobs`, to enhance filtering capabilities in the Nightwatch package. The changes encompass updates to configuration files, core logic, and tests to support this feature.

### Configuration Updates:
* [`config/nightwatch.php`](diffhunk://#diff-29c4b597d60a8022cc4979c7885460fdd8bc963a7c12afb270330a679f8ea045R21): Added the `ignore_queued_jobs` configuration option to allow users to toggle filtering of queued jobs.

### Core Logic Enhancements:
* [`src/Core.php`](diffhunk://#diff-3822a790a5cac9e3e980820c9ad0d8184339090889a97e65ea3b1a81a63ab52fR45): Updated the `$config` type definition to include the new `ignore_queued_jobs` option.
* [`src/Concerns/CapturesState.php`](diffhunk://#diff-b32b8d2bceda270f00a10d0862c98d141f5ea7be39930fc0ba54fcffbe4e1668L236-R236): Modified the `queuedJob` method to respect the `ignore_queued_jobs` configuration, ensuring queued jobs are ignored when specified.
* [`src/NightwatchServiceProvider.php`](diffhunk://#diff-f418488ec2f97353bcc9eaf797747e525178b3746278ca795966c7b0aea2c883R254): Registered the `ignore_queued_jobs` option in the Nightwatch service provider.

### Testing Additions:
* [`tests/FakeJob.php`](diffhunk://#diff-ae8740f92e1afa0cc38fc6ff7c38e01161cb80f3d5be036b62f062b0855eca9bR6-R17): Added the `Dispatchable` trait and implemented a `handle` method for the `FakeJob` class to facilitate testing of queued jobs.
* `tests/Unit/FilteringTest.php`: 
  - Imported additional dependencies to support the new tests. [[1]](diffhunk://#diff-f08a1f2dfbaab263715dce262e326fd403cc5b9a2d6e5151cf4304a59820637aR9-R14) [[2]](diffhunk://#diff-f08a1f2dfbaab263715dce262e326fd403cc5b9a2d6e5151cf4304a59820637aR31-R34)
  - Added a test case, `test_it_can_ignore_queued_jobs`, to verify that the `ignore_queued_jobs` configuration correctly filters queued jobs when enabled.