### PR TITLE
Improve user guard resolution

### DIFF
--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -50,18 +50,11 @@ final class UserProvider
             return $this->currentUserId();
         }
 
-        return '';
-    }
-
-    private function currentUserId(): string
-    {
-        try {
-            return Str::tinyText((string) $this->auth->id());
-        } catch (Throwable $e) {
-            $this->reportResolvingUserIdException($e);
-
-            return '';
+        if ($this->rememberedUser) {
+            return $this->rememberedUserId();
         }
+
+        return '';
     }
 
     /**
@@ -75,23 +68,37 @@ final class UserProvider
             }
 
             if ($this->auth->hasUser()) {
-                try {
-                    return Str::tinyText((string) $this->auth->id());
-                } catch (Throwable $e) {
-                    $this->reportResolvingUserIdException($e);
-
-                    return '';
-                }
-            } else {
-                try {
-                    return Str::tinyText((string) $this->rememberedUser?->getAuthIdentifier());  // @phpstan-ignore cast.string
-                } catch (Throwable $e) {
-                    $this->reportResolvingUserIdException($e);
-
-                    return '';
-                }
+                return $this->currentUserId();
             }
+
+            if ($this->rememberedUser) {
+                return $this->rememberedUserId();
+            }
+
+            return '';
         });
+    }
+
+    private function currentUserId(): string
+    {
+        try {
+            return Str::tinyText((string) $this->auth->id());
+        } catch (Throwable $e) {
+            $this->reportResolvingUserIdException($e);
+
+            return '';
+        }
+    }
+
+    private function rememberedUserId(): string
+    {
+        try {
+            return Str::tinyText((string) $this->rememberedUser?->getAuthIdentifier());  // @phpstan-ignore cast.string
+        } catch (Throwable $e) {
+            $this->reportResolvingUserIdException($e);
+
+            return '';
+        }
     }
 
     /**

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -43,17 +43,17 @@ final class UserProvider
     public function id(): LazyValue|string
     {
         if (! $this->auth->hasResolvedGuards()) {
-            return $this->lazyId();
+            return $this->lazyUserId();
         }
 
         if ($this->auth->hasUser()) {
-            return $this->currentId();
+            return $this->currentUserId();
         }
 
         return '';
     }
 
-    private function currentId(): string
+    private function currentUserId(): string
     {
         try {
             return Str::tinyText((string) $this->auth->id());
@@ -67,7 +67,7 @@ final class UserProvider
     /**
      * @return LazyValue<string>
      */
-    private function lazyId(): LazyValue
+    private function lazyUserId(): LazyValue
     {
         return new LazyValue(function () {
             if (! $this->auth->hasResolvedGuards()) {

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -64,6 +64,9 @@ final class UserProvider
         }
     }
 
+    /**
+     * @return LazyValue<string>
+     */
     private function lazyId(): LazyValue
     {
         return new LazyValue(function () {
@@ -96,11 +99,9 @@ final class UserProvider
      */
     public function details(): ?array
     {
-        if ($this->auth->hasResolvedGuards()) {
-            $user = $this->auth->user() ?? $this->rememberedUser;
-        } else {
-            $user = $this->rememberedUser;
-        }
+        $user = $this->auth->hasResolvedGuards()
+            ? $this->auth->user() ?? $this->rememberedUser
+            : $this->rememberedUser;
 
         if ($user === null) {
             return null;

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -42,27 +42,51 @@ final class UserProvider
      */
     public function id(): LazyValue|string
     {
+        if (! $this->auth->hasResolvedGuards()) {
+            return $this->lazyId();
+        }
+
+        if ($this->auth->hasUser()) {
+            return $this->currentId();
+        }
+
+        return '';
+    }
+
+    private function currentId(): string
+    {
         try {
-            if ($this->auth->hasUser()) {
-                return Str::tinyText((string) $this->auth->id());
-            }
+            return Str::tinyText((string) $this->auth->id());
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
             return '';
         }
+    }
 
+    private function lazyId(): LazyValue
+    {
         return new LazyValue(function () {
-            try {
-                if ($this->auth->hasUser()) {
-                    return Str::tinyText((string) $this->auth->id());
-                } else {
-                    return Str::tinyText((string) $this->rememberedUser?->getAuthIdentifier());  // @phpstan-ignore cast.string
-                }
-            } catch (Throwable $e) {
-                $this->reportResolvingUserIdException($e);
-
+            if (! $this->auth->hasResolvedGuards()) {
                 return '';
+            }
+
+            if ($this->auth->hasUser()) {
+                try {
+                    return Str::tinyText((string) $this->auth->id());
+                } catch (Throwable $e) {
+                    $this->reportResolvingUserIdException($e);
+
+                    return '';
+                }
+            } else {
+                try {
+                    return Str::tinyText((string) $this->rememberedUser?->getAuthIdentifier());  // @phpstan-ignore cast.string
+                } catch (Throwable $e) {
+                    $this->reportResolvingUserIdException($e);
+
+                    return '';
+                }
             }
         });
     }
@@ -72,7 +96,11 @@ final class UserProvider
      */
     public function details(): ?array
     {
-        $user = $this->auth->user() ?? $this->rememberedUser;
+        if ($this->auth->hasResolvedGuards()) {
+            $user = $this->auth->user() ?? $this->rememberedUser;
+        } else {
+            $user = $this->rememberedUser;
+        }
 
         if ($user === null) {
             return null;

--- a/tests/Feature/Sensors/UserSensorTest.php
+++ b/tests/Feature/Sensors/UserSensorTest.php
@@ -249,7 +249,7 @@ class UserSensorTest extends TestCase
         $ingest->assertLatestWrite('request:0.user', '');
     }
 
-    public function test_it_does_not_resolve_guards_unless_they_are_already_resolved(): void
+    public function test_it_does_not_actively_resolve_guards(): void
     {
         Route::get('/test', fn () => 'ok');
 

--- a/tests/Feature/Sensors/UserSensorTest.php
+++ b/tests/Feature/Sensors/UserSensorTest.php
@@ -248,4 +248,14 @@ class UserSensorTest extends TestCase
         $ingest->assertLatestWrite('query:1.user', '');
         $ingest->assertLatestWrite('request:0.user', '');
     }
+
+    public function test_it_does_not_resolve_guards_unless_they_are_already_resolved(): void
+    {
+        Route::get('/test', fn () => 'ok');
+
+        $response = $this->get('/test');
+
+        $response->assertOk();
+        $this->assertFalse(Auth::hasResolvedGuards());
+    }
 }

--- a/tests/Unit/UserProviderTest.php
+++ b/tests/Unit/UserProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Models\User;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Nightwatch\UserProvider;
@@ -15,6 +16,13 @@ use function strlen;
 
 class UserProviderTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->forceRequestExecutionState();
+
+        parent::setUp();
+    }
+
     public function test_it_limits_the_length_of_the_user_identifier(): void
     {
         Auth::login(new GenericUser([
@@ -41,12 +49,12 @@ class UserProviderTest extends TestCase
 
     public function test_it_can_remember_an_authenticated_user_and_limits_the_length_of_their_identifier(): void
     {
-        $provider = new UserProvider($this->app['auth'], fn () => [], fn () => fn () => null);
-        $provider->remember($user = new GenericUser([
+        Auth::login((new User([
             'id' => str_repeat('x', 1000),
-        ]));
+        ]))->setKeyType('string'));
+        Auth::logout();
 
-        $this->assertSame(str_repeat('x', 255), $provider->id()->jsonSerialize());
+        $this->assertSame(str_repeat('x', 255), $this->core->executionState->user->id());
     }
 
     public function test_it_only_reports_exceptions_occurring_while_resolving_user_ids_once_before_user_is_available(): void


### PR DESCRIPTION
When we call `Auth::hasUser` we are actively resolving an authentication guard if one has not yet been resolved. This is causing issues with some packages that dynamically configure the authentication guard late in the application's lifecycle.

This PR avoids resolving the auth guard and only calls `Auth::hasUser` once we know there has been a guard resolved.