### PR TITLE
Fix Beanstalkd job monitoring

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -482,6 +482,7 @@ trait CapturesState
      */
     public function prepareForJob(Job $job): void
     {
+        /** @var Core<CommandState> $this */
         if ($this->isVapor()) {
             $this->prepareForNextJob();
         }

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -494,6 +494,14 @@ trait CapturesState
         $this->executionState->timestamp = $this->clock->microtime();
         $this->executionState->setId((string) Str::uuid());
         $this->executionState->executionPreview = Str::tinyText($job->resolveName());
+
+        // Beanstalkd throws an exception when attempting to retrieve the job
+        // after it has been processed. Previously, we were retrieving the attempts
+        // when listening for the `JobProcessed|JobReleasedAfterException|JobFailed`
+        // events, however the job has already been removed from beanstalkd
+        // when these events fire. Instead, we will capture it much earlier in
+        // the lifecycle to ensure we can always retrieve the value.
+        $this->executionState->attempts = $job->attempts();
     }
 
     /**

--- a/src/Sensors/JobAttemptSensor.php
+++ b/src/Sensors/JobAttemptSensor.php
@@ -56,7 +56,7 @@ final class JobAttemptSensor
             // --- //
             'job_id' => $event->job->uuid(),
             'attempt_id' => $this->commandState->id(),
-            'attempt' => $event->job->attempts(),
+            'attempt' => $this->commandState->attempts,
             'name' => $name,
             'connection' => $event->job->getConnectionName(),
             'queue' => $this->normalizeQueue($event->job->getConnectionName(), $event->job->getQueue()),

--- a/src/State/CommandState.php
+++ b/src/State/CommandState.php
@@ -67,6 +67,7 @@ final class CommandState
         public NullUserProvider $user = new NullUserProvider,
         public string $executionPreview = '',
         public string $exceptionPreview = '',
+        public int $attempts = 0,
     ) {
         $this->deploy = Str::tinyText($this->deploy);
         $this->server = Str::tinyText($this->server);

--- a/tests/Feature/Sensors/JobAttemptSensorTest.php
+++ b/tests/Feature/Sensors/JobAttemptSensorTest.php
@@ -15,8 +15,11 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\SendQueuedMailable;
 use Illuminate\Queue\CallQueuedClosure;
+use Illuminate\Queue\Connectors\DatabaseConnector;
 use Illuminate\Queue\Connectors\SqsConnector;
+use Illuminate\Queue\DatabaseQueue;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Jobs\DatabaseJob;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Facades\Artisan;
@@ -936,6 +939,53 @@ class JobAttemptSensorTest extends TestCase
             ]);
         });
     }
+
+    public function test_it_works(): void
+    {
+        $ingest = $this->fakeIngest();
+        Queue::addConnector('database', function () {
+            return new class($this->app['db']) extends DatabaseConnector {
+                public function connect(array $config)
+                {
+                    return new class(
+                        $this->connections->connection($config['connection'] ?? null),
+                        $config['table'],
+                        $config['queue'],
+                        $config['retry_after'] ?? 60,
+                        $config['after_commit'] ?? null
+                    ) extends DatabaseQueue {
+                        protected function marshalJob($queue, $job)
+                        {
+                            return new class(
+                                $this->container,
+                                $this,
+                                $this->markJobAsReserved($job),
+                                $this->connectionName,
+                                $queue,
+                            ) extends DatabaseJob {
+                                public function attempts()
+                                {
+                                    if ($this->instance?->handled) {
+                                        throw new RuntimeException('Job has been deleted');
+                                    }
+
+                                    return 1;
+                                }
+                            };
+                        }
+                    };
+                }
+            };
+        });
+
+        JobThatMarksItselfAsHandled::dispatch();
+
+        Artisan::call('queue:work', $this->workOptions('queue:work'));
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('exception:*', []);
+        $ingest->assertLatestWrite('job-attempt:0.attempt', 1);
+    }
 }
 
 final class ProcessedJob implements ShouldQueue
@@ -1006,5 +1056,17 @@ class JobAttemptMail extends Mailable
         return new Content(
             view: 'mail',
         );
+    }
+}
+
+class JobThatMarksItselfAsHandled implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $handled = false;
+
+    public function handle(): void
+    {
+        $this->handled = true;
     }
 }

--- a/tests/Feature/Sensors/JobAttemptSensorTest.php
+++ b/tests/Feature/Sensors/JobAttemptSensorTest.php
@@ -940,7 +940,7 @@ class JobAttemptSensorTest extends TestCase
         });
     }
 
-    public function test_it_works(): void
+    public function test_queue_workers_that_remove_successful_jobs_and_make_network_call_to_determine_attempts_like_beanstalkd_can_capture_attempts(): void
     {
         $ingest = $this->fakeIngest();
         Queue::addConnector('database', function () {

--- a/tests/Feature/Sensors/JobAttemptSensorTest.php
+++ b/tests/Feature/Sensors/JobAttemptSensorTest.php
@@ -944,25 +944,16 @@ class JobAttemptSensorTest extends TestCase
     {
         $ingest = $this->fakeIngest();
         Queue::addConnector('database', function () {
-            return new class($this->app['db']) extends DatabaseConnector {
+            return new class($this->app['db']) extends DatabaseConnector
+            {
                 public function connect(array $config)
                 {
-                    return new class(
-                        $this->connections->connection($config['connection'] ?? null),
-                        $config['table'],
-                        $config['queue'],
-                        $config['retry_after'] ?? 60,
-                        $config['after_commit'] ?? null
-                    ) extends DatabaseQueue {
+                    return new class($this->connections->connection($config['connection'] ?? null), $config['table'], $config['queue'], $config['retry_after'] ?? 60, $config['after_commit'] ?? null) extends DatabaseQueue
+                    {
                         protected function marshalJob($queue, $job)
                         {
-                            return new class(
-                                $this->container,
-                                $this,
-                                $this->markJobAsReserved($job),
-                                $this->connectionName,
-                                $queue,
-                            ) extends DatabaseJob {
+                            return new class($this->container, $this, $this->markJobAsReserved($job), $this->connectionName, $queue) extends DatabaseJob
+                            {
                                 public function attempts()
                                 {
                                     if ($this->instance?->handled) {


### PR DESCRIPTION
When using the Beanstalkd queue driver, the `attempts` method will throw an exception after the job has successfully been processed.

```php
Event::listen(function (JobProcessed $job) {
    echo 'attempts: '.$job->job->attempts(); // Throws an exception
});
```

This is because a network request is made but by this time the job has already been removed from the queue.

I've rearranged the logic here so attempts is part of the execution state allowing us to capture it earlier in the job's lifecycle when we know the job is still on the queue.

From what I can see, this should not impact any other first-party queue workers.