### PR TITLE
Preserve zero fractions for log context and extra

### DIFF
--- a/src/Sensors/LogSensor.php
+++ b/src/Sensors/LogSensor.php
@@ -42,8 +42,8 @@ final class LogSensor
             // --- //
             'level' => Str::tinyText($record->level->toPsrLogLevel()),
             'message' => Str::text($record->message),
-            'context' => Str::mediumText(json_encode((object) $record->context, flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE)),
-            'extra' => Str::mediumText(json_encode((object) $record->extra, flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE)),
+            'context' => Str::mediumText(json_encode((object) $record->context, flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION)),
+            'extra' => Str::mediumText(json_encode((object) $record->extra, flags: JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION)),
         ];
     }
 }

--- a/tests/Feature/Sensors/LogSensorTest.php
+++ b/tests/Feature/Sensors/LogSensorTest.php
@@ -334,4 +334,24 @@ class LogSensorTest extends TestCase
         $ingest->assertLatestWrite('log:3.level', 'alert');
         $ingest->assertLatestWrite('log:4.level', 'emergency');
     }
+
+    public function test_it_preserves_zero_fractions_for_context_and_extra()
+    {
+        $ingest = $this->fakeIngest();
+        Log::channel('nightwatch')->pushProcessor(fn (LogRecord $record) => $record->with(extra: [
+            'extra' => 2.0,
+        ]));
+        Route::get('/users', function (): void {
+            Log::channel('nightwatch')->info('Hello world!', [
+                'context' => 1.0,
+            ]);
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('log:0.context', '{"context":1.0}');
+        $ingest->assertLatestWrite('log:0.extra', '{"extra":2.0}');
+    }
 }


### PR DESCRIPTION
Ensures that floats with zero fractions, e.g., `1.0`, are captured as floats and not ints.