### PR TITLE
fix: Prevent JSON exception handling trace when NIGHTWATCH_ENABLED=false

### DIFF
--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -27,7 +27,7 @@ final class LogHandler implements HandlerInterface
 
     public function isHandling(LogRecord $record): bool
     {
-        return $this->nightwatch->shouldCaptureLogs() && $this->level->includes($record->level);
+        return $this->nightwatch->enabled() && $this->nightwatch->shouldCaptureLogs() && $this->level->includes($record->level);
     }
 
     public function handle(LogRecord $record): bool

--- a/src/Hooks/LogRecordProcessor.php
+++ b/src/Hooks/LogRecordProcessor.php
@@ -33,6 +33,10 @@ final class LogRecordProcessor implements ProcessorInterface
 
     public function __invoke(LogRecord $record): LogRecord
     {
+        if (! $this->nightwatch->enabled()) {
+            return $record;
+        }
+
         try {
             /** @var array<string, mixed> */
             $formatted = $this->formatter()->format($record);

--- a/tests/Unit/Hooks/LogHandlerTest.php
+++ b/tests/Unit/Hooks/LogHandlerTest.php
@@ -70,6 +70,16 @@ class LogHandlerTest extends TestCase
         }
     }
 
+    public function test_it_respects_enabled(): void
+    {
+        $this->core->config['enabled'] = false;
+
+        $handler = new LogHandler($this->core, Level::Debug);
+        $record = new LogRecord(CarbonImmutable::now(), 'nightwatch', Level::Debug, 'hello world');
+        $this->assertFalse($handler->isHandling($record));
+        $this->assertFalse($handler->handle($record));
+    }
+
     public static function logLevelProvider(): array
     {
         return [

--- a/tests/Unit/Hooks/LogRecordProcessorTest.php
+++ b/tests/Unit/Hooks/LogRecordProcessorTest.php
@@ -31,4 +31,27 @@ class LogRecordProcessorTest extends TestCase
         $this->assertTrue($record->thrownInWith);
         $this->assertSame(1, $this->core->executionState->exceptions);
     }
+
+    public function test_it_respects_enabled(): void
+    {
+        $this->core->config['enabled'] = false;
+
+        $record = new class(new DateTimeImmutable, 'single', Level::Debug, 'Hello world') extends LogRecord
+        {
+            public bool $thrownInWith = false;
+
+            public function with(mixed ...$args): self
+            {
+                $this->thrownInWith = true;
+
+                throw new RuntimeException('Whoops!');
+            }
+        };
+
+        $processor = new LogRecordProcessor($this->core, 'Y-m-d H:i:s');
+        $processor($record);
+
+        $this->assertFalse($record->thrownInWith);
+        $this->assertSame(0, $this->core->executionState->exceptions);
+    }
 }


### PR DESCRIPTION
Nightwatch agent would change the exception output to JSON even when it's disabled


```bash
php artisan tinker --execute 'report(new Exception(123))'
```

## Expected Result
```
[2025-08-18 13:13:02] local.ERROR: 123 {"exception":"[object] (Exception(code: 0): 123 at /Users/mathiasgrimm/laravel.com/github/support/nightwatch-log-test/vendor/psy/psysh/src/ExecutionClosure.php(40) : eval()'d code:1)
[stacktrace]
#0 /User
.... 
```

## Actual Result
```
[2025-08-18 13:13:13] local.ERROR: 123 {"exception":{"class":"Exception","message":"123","code":0,"file":"/Users/mathiasgrimm/laravel.com/github/support/nightwatch-log-test/vendor/psy/psysh/src/ExecutionClosure.php(40) : eval()'d code:1","trace":["/Users/mathiasgrimm/laravel.c...
```