### PR TITLE
Handle Run In Background Scheduled Tasks

### DIFF
--- a/src/Hooks/ScheduledTaskListener.php
+++ b/src/Hooks/ScheduledTaskListener.php
@@ -36,7 +36,8 @@ final class ScheduledTaskListener
             Compatibility::$firesFinishedAndFailedEventsForScheduledConsoleCommands &&
             $event instanceof ScheduledTaskFinished &&
             $event->task->command !== null &&
-            $event->task->exitCode !== 0
+            $event->task->exitCode !== 0 &&
+            $event->task->exitCode !== null
         ) {
             return;
         }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

We noticed in our primary application that Scheduled Tasks with `->runInBackground()` were no longer being sent to Nightwatch after we deployed a set of dependency updates. To try and debug this, we made a test setup that was essentially the following `console.php` and ran a fake nightwatch agent that just logged what it received in the background.

```php
Schedule::command('model:prune')
	->runInBackground()
	->everyMinute();
```

From here we ran a git bisect on all of the relevant packages and our own application to determine the cause. That lead us to #177.

If we add a listener in our app for the `ScheduledTaskFinished` event and then `dd($event->task)`, you can see that the `exitCode` is `null` when it's set to run in the background. Whereas if you don't set it to run in the background, it will have a valid exit code. That means that `$event->task->exitCode !== 0` check added in the afforementioned PR will always evaluate to true for background scheduled tasks.

Now, admittedly I'm not sure if this is 100% the correct fix for this issue. There exists the `ScheduledBackgroundTaskFinished` event that Nightwatch is not currently listening to that would indicate the actual exit code for the scheduled task and not just a pretty much default `0` with an average runtime of just a few ms. From a cursory glance, I think a PR that adds in that event to the union would be the more "correct" fix, but you'd likely then need to ignore the regular `ScheduledTaskFinished` event for them to avoid reporting on them twice.

Depending on how much time I have in the next week, I'll see if I can also explore that avenue as a fix for this issue. The `null` exit code was just the easier option for a quick PR.