### PR TITLE
Capture scheduled tasks that run in background

### DIFF
--- a/src/Hooks/ScheduledTaskListener.php
+++ b/src/Hooks/ScheduledTaskListener.php
@@ -32,12 +32,7 @@ final class ScheduledTaskListener
             $this->nightwatch->report($event->exception);
         }
 
-        if (
-            Compatibility::$firesFinishedAndFailedEventsForScheduledConsoleCommands &&
-            $event instanceof ScheduledTaskFinished &&
-            $event->task->command !== null &&
-            $event->task->exitCode !== 0
-        ) {
+        if ($this->isFinishedEventForFailedTask($event)) {
             return;
         }
 
@@ -48,5 +43,14 @@ final class ScheduledTaskListener
         }
 
         $this->nightwatch->digest();
+    }
+
+    private function isFinishedEventForFailedTask(ScheduledTaskFinished|ScheduledTaskSkipped|ScheduledTaskFailed $event): bool
+    {
+        return Compatibility::$firesFinishedAndFailedEventsForScheduledConsoleCommands &&
+            $event instanceof ScheduledTaskFinished &&
+            $event->task->command !== null &&
+            $event->task->exitCode !== 0 &&
+            ! $event->task->runInBackground;
     }
 }

--- a/tests/Feature/Sensors/ScheduledTaskSensorTest.php
+++ b/tests/Feature/Sensors/ScheduledTaskSensorTest.php
@@ -189,7 +189,56 @@ class ScheduledTaskSensorTest extends TestCase
         $ingest->assertLatestWrite('exception:0.message', 'Unhandled error');
     }
 
-    public function test_it_resets_trace_i_d_and_timestamp_on_each_task_run(): void
+    public function test_it_ingests_tasks_run_in_background(): void
+    {
+        $ingest = $this->fakeIngest();
+        Artisan::command('app:fly {destination} {--force} {--compress}', function (): void {
+            $this->travelTo(now()->addMicroseconds(1_000_000));
+        });
+
+        $task = $this->app[Schedule::class]->command('app:fly tokyo')->everyMinute()->runInBackground();
+
+        Artisan::call('schedule:run');
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('scheduled-task:*', [
+            [
+                'v' => 1,
+                't' => 'scheduled-task',
+                'timestamp' => 946688523.456789,
+                'deploy' => 'v1.2.3',
+                'server' => 'scheduler-01',
+                '_group' => hash('xxh128', "php artisan app:fly tokyo,{$task->expression},{$task->timezone}"),
+                'trace_id' => '00000000-0000-0000-0000-000000000000',
+                'name' => 'php artisan app:fly tokyo',
+                'cron' => '* * * * *',
+                'timezone' => 'UTC',
+                'without_overlapping' => false,
+                'on_one_server' => false,
+                'run_in_background' => true,
+                'even_in_maintenance_mode' => false,
+                'status' => 'processed',
+                'duration' => 0,
+                'exceptions' => 0,
+                'logs' => 0,
+                'queries' => 0,
+                'lazy_loads' => 0,
+                'jobs_queued' => 0,
+                'mail' => 0,
+                'notifications' => 0,
+                'outgoing_requests' => 0,
+                'files_read' => 0,
+                'files_written' => 0,
+                'cache_events' => 0,
+                'hydrated_models' => 0,
+                'peak_memory_usage' => 1234,
+                'exception_preview' => '',
+                'context' => Compatibility::$contextExists ? '{}' : '',
+            ],
+        ]);
+    }
+
+    public function test_it_resets_trace_id_and_timestamp_on_each_task_run(): void
     {
         $ingest = $this->fakeIngest();
         $this->app[Schedule::class]->call(fn () => $this->travelTo(now()->addMicroseconds(1_000_000)))->everyMinute();


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR fixes an issue where background scheduled tasks are not captured on Laravel `=12.11.0` and `>=12.18.0`.