### PR TITLE
Allow the user ID to be customized

### DIFF
--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -97,7 +97,19 @@ final class UserProvider
     private function currentUserId(AuthManager $auth): string
     {
         try {
-            return Str::tinyText((string) $auth->id());
+            $user = $auth->user();
+
+            if ($user === null) {
+                return '';
+            }
+
+            $resolver = call_user_func($this->userDetailsResolverResolver);
+
+            if ($resolver === null) {
+                return Str::tinyText((string) $user->getAuthIdentifier()); // @phpstan-ignore cast.string
+            }
+
+            return Str::tinyText($resolver($user)['id'] ?? $user->getAuthIdentifier()); // @phpstan-ignore argument.type
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -59,11 +59,11 @@ final class UserProvider
             }
 
             if ($auth->hasUser()) {
-                return $this->currentUserId($auth);
+                return $this->userId($auth->user()); // @phpstan-ignore argument.type
             }
 
             if ($this->rememberedUser) {
-                return $this->rememberedUserId();
+                return $this->userId($this->rememberedUser);
             }
 
             return $this->lazyUserId();
@@ -88,32 +88,21 @@ final class UserProvider
             }
 
             if ($auth->hasUser()) {
-                return $this->currentUserId($auth);
+                return $this->userId($auth->user()); // @phpstan-ignore argument.type
             }
 
             if ($this->rememberedUser) {
-                return $this->rememberedUserId();
+                return $this->userId($this->rememberedUser);
             }
 
             return '';
         });
     }
 
-    private function currentUserId(AuthManager $auth): string
+    private function userId(Authenticatable $user): string
     {
         try {
-            return Str::tinyText((string) ($this->resolvedDetails($auth->user())['id'] ?? '')); // @phpstan-ignore cast.string
-        } catch (Throwable $e) {
-            $this->reportResolvingUserIdException($e);
-
-            return '';
-        }
-    }
-
-    private function rememberedUserId(): string
-    {
-        try {
-            return Str::tinyText((string) ($this->resolvedDetails($this->rememberedUser)['id'] ?? '')); // @phpstan-ignore cast.string
+            return Str::tinyText((string) ($this->resolvedDetails($user)['id'] ?? '')); // @phpstan-ignore cast.string
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -24,7 +24,7 @@ final class UserProvider
     /**
      * @var array{id: mixed, name?: mixed, username?: mixed}
      */
-    private ?array $resolvedDetails;
+    private array $resolvedDetails;
 
     /**
      * @var (callable(callable(AuthManager): mixed): mixed)

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -120,7 +120,17 @@ final class UserProvider
     private function rememberedUserId(): string
     {
         try {
-            return Str::tinyText((string) $this->rememberedUser?->getAuthIdentifier());  // @phpstan-ignore cast.string
+            if ($this->rememberedUser === null) {
+                return '';
+            }
+
+            $resolver = call_user_func($this->userDetailsResolverResolver);
+
+            if ($resolver === null) {
+                return Str::tinyText((string) $this->rememberedUser->getAuthIdentifier()); // @phpstan-ignore cast.string
+            }
+
+            return Str::tinyText($resolver($this->rememberedUser)['id'] ?? $this->rememberedUser->getAuthIdentifier()); // @phpstan-ignore argument.type
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -22,6 +22,11 @@ final class UserProvider
     public $userDetailsResolverResolver;
 
     /**
+     * @var array{id: mixed, name?: mixed, username?: mixed}
+     */
+    private ?array $resolvedDetails;
+
+    /**
      * @var (callable(callable(AuthManager): mixed): mixed)
      */
     private $withAuth;
@@ -103,13 +108,7 @@ final class UserProvider
                 return '';
             }
 
-            $resolver = call_user_func($this->userDetailsResolverResolver);
-
-            if ($resolver === null) {
-                return Str::tinyText((string) $user->getAuthIdentifier()); // @phpstan-ignore cast.string
-            }
-
-            return Str::tinyText($resolver($user)['id'] ?? $user->getAuthIdentifier()); // @phpstan-ignore argument.type
+            return Str::tinyText($this->resolvedDetails($user)['id'] ?? ''); // @phpstan-ignore argument.type
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
@@ -124,13 +123,7 @@ final class UserProvider
                 return '';
             }
 
-            $resolver = call_user_func($this->userDetailsResolverResolver);
-
-            if ($resolver === null) {
-                return Str::tinyText((string) $this->rememberedUser->getAuthIdentifier()); // @phpstan-ignore cast.string
-            }
-
-            return Str::tinyText($resolver($this->rememberedUser)['id'] ?? $this->rememberedUser->getAuthIdentifier()); // @phpstan-ignore argument.type
+            return Str::tinyText($this->resolvedDetails($this->rememberedUser)['id'] ?? ''); // @phpstan-ignore argument.type
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
@@ -151,6 +144,18 @@ final class UserProvider
             return null;
         }
 
+        return $this->resolvedDetails($user);
+    }
+
+    /**
+     * @return array{ id: mixed, name?: mixed, username?: mixed }|null
+     */
+    private function resolvedDetails(Authenticatable $user): ?array
+    {
+        if (isset($this->resolvedDetails)) {
+            return $this->resolvedDetails;
+        }
+
         try {
             $id = $user->getAuthIdentifier();
         } catch (Throwable $e) {
@@ -162,14 +167,14 @@ final class UserProvider
         $resolver = call_user_func($this->userDetailsResolverResolver);
 
         if ($resolver === null) {
-            return [
+            return $this->resolvedDetails = [
                 'id' => $id,
                 'name' => $user->name ?? '',
                 'username' => $user->email ?? '',
             ];
         }
 
-        return [
+        return $this->resolvedDetails = [
             'id' => $id,
             ...$resolver($user),
         ];

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -102,13 +102,7 @@ final class UserProvider
     private function currentUserId(AuthManager $auth): string
     {
         try {
-            $user = $auth->user();
-
-            if ($user === null) {
-                return '';
-            }
-
-            return Str::tinyText($this->resolvedDetails($user)['id'] ?? ''); // @phpstan-ignore argument.type
+            return Str::tinyText((string) ($this->resolvedDetails($auth->user())['id'] ?? '')); // @phpstan-ignore cast.string
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
@@ -119,11 +113,7 @@ final class UserProvider
     private function rememberedUserId(): string
     {
         try {
-            if ($this->rememberedUser === null) {
-                return '';
-            }
-
-            return Str::tinyText($this->resolvedDetails($this->rememberedUser)['id'] ?? ''); // @phpstan-ignore argument.type
+            return Str::tinyText((string) ($this->resolvedDetails($this->rememberedUser)['id'] ?? '')); // @phpstan-ignore cast.string
         } catch (Throwable $e) {
             $this->reportResolvingUserIdException($e);
 
@@ -140,18 +130,18 @@ final class UserProvider
             ? $auth->user() ?? $this->rememberedUser
             : $this->rememberedUser);
 
-        if ($user === null) {
-            return null;
-        }
-
         return $this->resolvedDetails($user);
     }
 
     /**
      * @return array{ id: mixed, name?: mixed, username?: mixed }|null
      */
-    private function resolvedDetails(Authenticatable $user): ?array
+    private function resolvedDetails(?Authenticatable $user): ?array
     {
+        if ($user === null) {
+            return null;
+        }
+
         if (isset($this->resolvedDetails)) {
             return $this->resolvedDetails;
         }

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -24,7 +24,7 @@ final class UserProvider
     /**
      * @var array{id: mixed, name?: mixed, username?: mixed}
      */
-    private array $resolvedDetails;
+    private ?array $resolvedDetails;
 
     /**
      * @var (callable(callable(AuthManager): mixed): mixed)
@@ -167,6 +167,7 @@ final class UserProvider
     public function flush(): void
     {
         $this->rememberedUser = null;
+        $this->resolvedDetails = null;
         $this->alreadyReportedResolvingUserIdException = false;
     }
 

--- a/tests/Feature/Sensors/UserSensorTest.php
+++ b/tests/Feature/Sensors/UserSensorTest.php
@@ -112,6 +112,7 @@ class UserSensorTest extends TestCase
             'name' => 'Tim',
             'username' => 'timacdonald',
         ]]);
+        $ingest->assertLatestWrite('request:0.user', '123');
     }
 
     public function test_it_handles_authenticatable_objects_without_name_or_email_properties(): void
@@ -173,6 +174,7 @@ class UserSensorTest extends TestCase
             'name' => '',
             'username' => '',
         ]]);
+        $ingest->assertLatestWrite('request:0.user', '123');
     }
 
     public function test_it_can_only_collect_the_user_id(): void
@@ -200,6 +202,7 @@ class UserSensorTest extends TestCase
             'name' => '',
             'username' => '',
         ]]);
+        $ingest->assertLatestWrite('request:0.user', '123');
     }
 
     public function test_it_it_captures_the_user_id_even_when_excluded_from_the_nightwatch_user_return_array(): void
@@ -225,6 +228,7 @@ class UserSensorTest extends TestCase
             'name' => '',
             'username' => '',
         ]]);
+        $ingest->assertLatestWrite('request:0.user', '567');
     }
 
     public function test_it_gracefully_handles_exceptions_while_resolving_user_ids(): void

--- a/tests/Unit/OctaneTest.php
+++ b/tests/Unit/OctaneTest.php
@@ -64,10 +64,15 @@ class OctaneTest extends TestCase
         $this->assertSame('Whoops!', $this->core->executionState->exceptionPreview);
         $this->assertSame('GET /test', $this->core->executionState->executionPreview);
         $this->assertSame(ExecutionStage::End, $this->core->executionState->stage);
+        $this->assertSame('5', $this->core->executionState->user->id());
 
         $this->core->uuid->uuidResolver = fn () => '8B4F773A-81AB-4273-97D5-C7BECBC173BE';
         $this->core->clock->microtimeResolver = fn () => 56789;
         $this->core->prepareForNextRequest();
+
+        $this->actingAs(new GenericUser([
+            'id' => 6,
+        ]));
 
         $this->assertSame('8B4F773A-81AB-4273-97D5-C7BECBC173BE', $this->core->executionState->id()->jsonSerialize());
         $this->assertSame('8B4F773A-81AB-4273-97D5-C7BECBC173BE', $this->core->executionState->trace);
@@ -87,5 +92,6 @@ class OctaneTest extends TestCase
         $this->assertSame(56789.0, $this->core->executionState->timestamp);
         $this->assertSame(56789.0, $this->core->executionState->currentExecutionStageStartedAtMicrotime);
         $this->assertSame(ExecutionStage::BeforeMiddleware, $this->core->executionState->stage);
+        $this->assertSame('6', $this->core->executionState->user->id());
     }
 }

--- a/tests/Unit/UserProviderTest.php
+++ b/tests/Unit/UserProviderTest.php
@@ -183,4 +183,31 @@ class UserProviderTest extends TestCase
         $ingest->assertLatestWrite('query:0.user', '123-456');
         $ingest->assertLatestWrite('request:0.user', '123-456');
     }
+
+    public function test_the_user_id_can_be_customized_when_the_user_logs_out(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::post('/logout', function () {
+            Auth::logout();
+            User::all();
+        });
+        $user = User::make([
+            'id' => '456',
+            'name' => 'Tim MacDonald',
+            'email' => 'tim@laravel.com',
+        ]);
+        Nightwatch::user(fn (Authenticatable $user) => [
+            'id' => '123-'.$user->getAuthIdentifier(),
+            'name' => $user->name,
+            'username' => $user->email,
+        ]);
+
+        $response = $this->actingAs($user)->post('/logout');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('user:0.id', '123-456');
+        $ingest->assertLatestWrite('query:0.user', '123-456');
+        $ingest->assertLatestWrite('request:0.user', '123-456');
+    }
 }

--- a/tests/Unit/UserProviderTest.php
+++ b/tests/Unit/UserProviderTest.php
@@ -259,4 +259,49 @@ class UserProviderTest extends TestCase
         $ingest->assertLatestWrite('query:0.user', '456');
         $ingest->assertLatestWrite('request:0.user', '456');
     }
+
+    public function test_it_doesnt_call_the_resolver_multiple_times(): void
+    {
+        $this->fakeIngest();
+        Route::get('/users', fn () => User::all());
+        $user = User::make();
+        $calls = 0;
+        Nightwatch::user(function (Authenticatable $user) use (&$calls) {
+            $calls++;
+
+            return [
+                'name' => $user->name,
+                'username' => $user->email,
+            ];
+        });
+
+        $response = $this->actingAs($user)->get('/users');
+
+        $response->assertOk();
+        $this->assertSame(1, $calls);
+    }
+
+    public function test_it_doesnt_call_the_resolver_multiple_times_when_logging_out(): void
+    {
+        $this->fakeIngest();
+        Route::post('/logout', function () {
+            Auth::logout();
+            User::all();
+        });
+        $user = User::make();
+        $calls = 0;
+        Nightwatch::user(function (Authenticatable $user) use (&$calls) {
+            $calls++;
+
+            return [
+                'name' => $user->name,
+                'username' => $user->email,
+            ];
+        });
+
+        $response = $this->actingAs($user)->post('/logout');
+
+        $response->assertOk();
+        $this->assertSame(1, $calls);
+    }
 }

--- a/tests/Unit/UserProviderTest.php
+++ b/tests/Unit/UserProviderTest.php
@@ -184,6 +184,29 @@ class UserProviderTest extends TestCase
         $ingest->assertLatestWrite('request:0.user', '123-456');
     }
 
+    public function test_it_allows_the_id_to_be_omitted_when_customizing(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/users', fn () => User::all());
+        $user = User::make([
+            'id' => '456',
+            'name' => 'Tim MacDonald',
+            'email' => 'tim@laravel.com',
+        ]);
+        Nightwatch::user(fn (Authenticatable $user) => [
+            'name' => $user->name,
+            'username' => $user->email,
+        ]);
+
+        $response = $this->actingAs($user)->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('user:0.id', '456');
+        $ingest->assertLatestWrite('query:0.user', '456');
+        $ingest->assertLatestWrite('request:0.user', '456');
+    }
+
     public function test_the_user_id_can_be_customized_when_the_user_logs_out(): void
     {
         $ingest = $this->fakeIngest();
@@ -209,5 +232,31 @@ class UserProviderTest extends TestCase
         $ingest->assertLatestWrite('user:0.id', '123-456');
         $ingest->assertLatestWrite('query:0.user', '123-456');
         $ingest->assertLatestWrite('request:0.user', '123-456');
+    }
+
+    public function test_the_id_can_be_omitted_when_customizing_and_the_user_logs_out(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::post('/logout', function () {
+            Auth::logout();
+            User::all();
+        });
+        $user = User::make([
+            'id' => '456',
+            'name' => 'Tim MacDonald',
+            'email' => 'tim@laravel.com',
+        ]);
+        Nightwatch::user(fn (Authenticatable $user) => [
+            'name' => $user->name,
+            'username' => $user->email,
+        ]);
+
+        $response = $this->actingAs($user)->post('/logout');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('user:0.id', '456');
+        $ingest->assertLatestWrite('query:0.user', '456');
+        $ingest->assertLatestWrite('request:0.user', '456');
     }
 }

--- a/tests/Unit/UserProviderTest.php
+++ b/tests/Unit/UserProviderTest.php
@@ -4,8 +4,11 @@ namespace Tests\Unit;
 
 use App\Models\User;
 use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Laravel\Nightwatch\Facades\Nightwatch;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -155,5 +158,29 @@ class UserProviderTest extends TestCase
         $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
         $ingest->assertLatestWrite('query:0.sql', 'select * from users');
         $ingest->assertLatestWrite('query:1.sql', 'select * from users');
+    }
+
+    public function test_the_user_id_can_be_customized(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/users', fn () => User::all());
+        $user = User::make([
+            'id' => '456',
+            'name' => 'Tim MacDonald',
+            'email' => 'tim@laravel.com',
+        ]);
+        Nightwatch::user(fn (Authenticatable $user) => [
+            'id' => '123-'.$user->getAuthIdentifier(),
+            'name' => $user->name,
+            'username' => $user->email,
+        ]);
+
+        $response = $this->actingAs($user)->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('user:0.id', '123-456');
+        $ingest->assertLatestWrite('query:0.user', '123-456');
+        $ingest->assertLatestWrite('request:0.user', '123-456');
     }
 }


### PR DESCRIPTION
This PR updates the [`Nightwatch::user`](https://nightwatch.laravel.com/docs/agent/advanced-configuration#customizing-user-details) method to support customization of the user ID for scenarios where the user ID is not unique (e.g. multi-table multi-tenancy with auto-incrementing IDs).

Example:

```php
use Illuminate\Contracts\Auth\Authenticatable;
use Laravel\Nightwatch\Facades\Nightwatch;

Nightwatch::user(fn (Authenticatable $user) => [
    'id' => "{$user->tenant_id}-{$user->id}",
    'name' => $user->name,
    'username' => $user->email,
]);
```