### PR TITLE
Add Missing Silent and Quiet Options in command signature

### DIFF
--- a/src/Console/AgentCommand.php
+++ b/src/Console/AgentCommand.php
@@ -21,7 +21,9 @@ final class AgentCommand extends Command
         {--auth-timeout=}
         {--ingest-connection-timeout=}
         {--ingest-timeout=}
-        {--server=}';
+        {--server=}
+        {--silent}
+        {--quiet}';
 
     /**
      * @var string
@@ -56,6 +58,6 @@ final class AgentCommand extends Command
 
         $quiet = $this->option('quiet') ?: null;
 
-        require __DIR__.'/../../agent/build/agent.phar';
+        require __DIR__ . '/../../agent/build/agent.phar';
     }
 }


### PR DESCRIPTION
On Laravel 10, the signature is missing silent and quiet options which were recently added and this throws an InvalidArgumentException when the agent is run.