### PR TITLE
Fix agent missing options

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -248,6 +248,9 @@ jobs:
         run: touch tests/database.sqlite
 
       - name: Execute tests
+        env:
+          NIGHTWATCH_TOKEN: ${{ secrets.NIGHTWATCH_TOKEN }}
+          NIGHTWATCH_BASE_URL: ${{ secrets.NIGHTWATCH_BASE_URL }}
         run: vendor/bin/phpunit --order-by=random --coverage-text
 
   agent_tests:

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/http-foundation": "^6.0|^7.0"
     },
     "require-dev": {
+        "ext-pcntl": "*",
         "ext-pdo": "*",
         "aws/aws-sdk-php": "^3.349",
         "guzzlehttp/guzzle": "^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,5 @@
         <env name="MAIL_MAILER" value="array" />
         <env name="QUEUE_CONNECTION" value="database" />
         <env name="SQS_PREFIX" value="https://sqs.us-east-1.amazonaws.com/123456789" />
-        <env name="NIGHTWATCH_TOKEN" value="80fbcc70cec46a6e30d1e3b1b46260ba282c8a0923f8" />
     </php>
 </phpunit>

--- a/src/Console/AgentCommand.php
+++ b/src/Console/AgentCommand.php
@@ -21,7 +21,8 @@ final class AgentCommand extends Command
         {--auth-timeout=}
         {--ingest-connection-timeout=}
         {--ingest-timeout=}
-        {--server=}';
+        {--server=}
+        {--silent : Do not output any message}';
 
     /**
      * @var string

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -21,13 +21,24 @@ class AgentCommandTest extends TestCase
             $result = $process->wait(function ($type, $o) use (&$output, $process) {
                 $output .= $o;
 
-                if (str_contains($o, 'Authentication successful')) {
-                    $process->signal(SIGTERM);
-                    sleep(2);
-                    if ($process->running()) {
-                        $process->signal(SIGKILL);
-                    }
+                if (! str_contains($o, 'Authentication successful')) {
+                    return;
                 }
+
+                $process->signal(SIGTERM);
+
+                $tries = 0;
+
+                while ($tries < 3) {
+                    if (! $process->running()) {
+                        return;
+                    }
+
+                    $tries++;
+                    sleep(1);
+                }
+
+                $process->signal(SIGKILL);
             });
         } catch (ProcessTimedOutException $e) {
             throw new RuntimeException('Failed to authenticate or stop the agent running. Output:'.PHP_EOL.$output, previous: $e);

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -19,8 +19,8 @@ class AgentCommandTest extends TestCase
             $result = $process->wait(function ($type, $o) use (&$output, $process) {
                 $output .= $o;
 
-                if ($type === 'out' && str_contains($o, 'Authentication successful')) {
-                    $process->signal(SIGKILL);
+                if (str_contains($o, 'Authentication successful')) {
+                    $process->signal(SIGTERM);
                 }
             });
         } catch (ProcessTimedOutException $e) {

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature\Console;
 use Illuminate\Support\Facades\Process;
 use Tests\TestCase;
 
+use function collect;
+use function rescue;
 use function str_contains;
 use function with;
 
@@ -12,17 +14,17 @@ class AgentCommandTest extends TestCase
 {
     public function test_it_can_run_the_agent_command(): void
     {
-        $result = with(Process::timeout(5)->start('vendor/bin/testbench nightwatch:agent'), function ($process) {
-            return $process->wait(function ($type, $output) use ($process) {
-                if ($type === 'out' && str_contains($output, 'Authentication successful')) {
-                    $process->signal(SIGINT);
-                }
-            });
-        })->throw();
+        $output = collect();
+        $result = with(Process::timeout(5)->start('vendor/bin/testbench nightwatch:agent'), function ($process) use ($output) {
+            return rescue(fn () => $process->wait(function ($type, $o) use ($output) {
+                $output[] = $o;
 
-        // The above will throw an exception if it times out. So if we get here,
-        // we know the agent command started as expected. Not need for any command
-        // specific assertions here.
-        $this->assertTrue(true);
+                if ($type === 'out' && str_contains($o, 'Authentication successful')) {
+                    // $process->signal(SIGINT);
+                }
+            }), report: false);
+        });
+
+        $this->assertNotNull($result, $output->implode(PHP_EOL));
     }
 }

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -2,29 +2,32 @@
 
 namespace Tests\Feature\Console;
 
+use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Support\Facades\Process;
 use Tests\TestCase;
 
-use function collect;
-use function rescue;
 use function str_contains;
-use function with;
 
 class AgentCommandTest extends TestCase
 {
     public function test_it_can_run_the_agent_command(): void
     {
-        $output = collect();
-        $result = with(Process::timeout(5)->start('vendor/bin/testbench nightwatch:agent'), function ($process) use ($output) {
-            return rescue(fn () => $process->wait(function ($type, $o) use ($output) {
-                $output[] = $o;
+        $output = '';
+        $process = Process::timeout(5)->start('vendor/bin/testbench nightwatch:agent');
+        try {
+            $result = $process->wait(function ($type, $o) use (&$output, $process) {
+                $output .= $o;
 
                 if ($type === 'out' && str_contains($o, 'Authentication successful')) {
                     $process->signal(SIGINT);
                 }
-            }), report: false);
-        });
+            });
+        } catch (ProcessTimedOutException $e) {
+            echo $output;
 
-        $this->assertNotNull($result, $output->implode(''));
+            throw $e;
+        }
+
+        $this->assertStringContainsString('Authentication successful', $output);
     }
 }

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Process;
+use Tests\TestCase;
+
+use function str_contains;
+use function with;
+
+class AgentCommandTest extends TestCase
+{
+    public function test_it_can_run_the_agent_command(): void
+    {
+        $result = with(Process::timeout(5)->start('vendor/bin/testbench nightwatch:agent'), function ($process) {
+            return $process->wait(function ($type, $output) use ($process) {
+                if ($type === 'out' && str_contains($output, 'Authentication successful')) {
+                    $process->signal(SIGINT);
+                }
+            });
+        })->throw();
+
+        // The above will throw an exception if it times out. So if we get here,
+        // we know the agent command started as expected. Not need for any command
+        // specific assertions here.
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Process;
 use RuntimeException;
 use Tests\TestCase;
 
+use function sleep;
 use function str_contains;
 
 class AgentCommandTest extends TestCase
@@ -14,13 +15,18 @@ class AgentCommandTest extends TestCase
     public function test_it_can_run_the_agent_command(): void
     {
         $output = '';
+        $process = Process::timeout(10)->start('vendor/bin/testbench nightwatch:agent');
 
         try {
-            Process::timeout(10)->run('vendor/bin/testbench nightwatch:agent', function ($type, $o) use (&$output, $process) {
+            $result = $process->wait(function ($type, $o) use (&$output, $process) {
                 $output .= $o;
 
                 if (str_contains($o, 'Authentication successful')) {
                     $process->signal(SIGTERM);
+                    sleep(2);
+                    if ($process->running()) {
+                        $process->signal(SIGKILL);
+                    }
                 }
             });
         } catch (ProcessTimedOutException $e) {

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -20,11 +20,11 @@ class AgentCommandTest extends TestCase
                 $output[] = $o;
 
                 if ($type === 'out' && str_contains($o, 'Authentication successful')) {
-                    // $process->signal(SIGINT);
+                    $process->signal(SIGINT);
                 }
             }), report: false);
         });
 
-        $this->assertNotNull($result, $output->implode(PHP_EOL));
+        $this->assertNotNull($result, $output->implode(''));
     }
 }

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -19,7 +19,7 @@ class AgentCommandTest extends TestCase
                 $output .= $o;
 
                 if ($type === 'out' && str_contains($o, 'Authentication successful')) {
-                    $process->signal(SIGINT);
+                    $process->signal(SIGKILL);
                 }
             });
         } catch (ProcessTimedOutException $e) {

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Console;
 
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Support\Facades\Process;
+use RuntimeException;
 use Tests\TestCase;
 
 use function str_contains;
@@ -13,7 +14,7 @@ class AgentCommandTest extends TestCase
     public function test_it_can_run_the_agent_command(): void
     {
         $output = '';
-        $process = Process::timeout(5)->start('vendor/bin/testbench nightwatch:agent');
+        $process = Process::timeout(10)->start('vendor/bin/testbench nightwatch:agent');
         try {
             $result = $process->wait(function ($type, $o) use (&$output, $process) {
                 $output .= $o;
@@ -23,9 +24,7 @@ class AgentCommandTest extends TestCase
                 }
             });
         } catch (ProcessTimedOutException $e) {
-            echo $output;
-
-            throw $e;
+            throw new RuntimeException('Failed to authenticate or stop the agent running. Output:'.PHP_EOL.$output, previous: $e);
         }
 
         $this->assertStringContainsString('Authentication successful', $output);

--- a/tests/Feature/Console/AgentCommandTest.php
+++ b/tests/Feature/Console/AgentCommandTest.php
@@ -14,9 +14,9 @@ class AgentCommandTest extends TestCase
     public function test_it_can_run_the_agent_command(): void
     {
         $output = '';
-        $process = Process::timeout(10)->start('vendor/bin/testbench nightwatch:agent');
+
         try {
-            $result = $process->wait(function ($type, $o) use (&$output, $process) {
+            Process::timeout(10)->run('vendor/bin/testbench nightwatch:agent', function ($type, $o) use (&$output, $process) {
                 $output .= $o;
 
                 if (str_contains($o, 'Authentication successful')) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -270,7 +270,7 @@ abstract class TestCase extends OrchestraTestCase
 
     public static function tokenHash(): string
     {
-        $refreshToken = $_ENV['NIGHTWATCH_TOKEN'] ?? '';
+        $refreshToken = $_SERVER['NIGHTWATCH_TOKEN'] ?? '';
 
         if (! is_string($refreshToken)) {
             throw new RuntimeException('NIGHTWATCH_TOKEN invalid');


### PR DESCRIPTION
We recently started respecting the `silent` and `quiet` command line flags.

These are not specified by default in older versions of Laravel, so when we retrieved them and exception is thrown.

This back ports the `silent` flag to support the older versions.