### PR TITLE
Add `Sample` middleware aliases

### DIFF
--- a/src/Http/Middleware/Sample.php
+++ b/src/Http/Middleware/Sample.php
@@ -30,6 +30,16 @@ class Sample
         return static::class.':'.$rate;
     }
 
+    public static function always(): string
+    {
+        return static::class.':1.0';
+    }
+
+    public static function never(): string
+    {
+        return static::class.':0.0';
+    }
+
     public function handle(Request $request, Closure $next, float $rate): mixed
     {
         try {

--- a/tests/Feature/Http/Middleware/SampleTest.php
+++ b/tests/Feature/Http/Middleware/SampleTest.php
@@ -20,7 +20,7 @@ class SampleTest extends TestCase
         $ingest = $this->fakeIngest();
 
         Route::get('/users-0', fn () => [])
-            ->middleware(Sample::rate(0));
+            ->middleware(Sample::never());
         $writes = 0;
 
         for ($i = 0; $i < 100; $i++) {
@@ -46,7 +46,7 @@ class SampleTest extends TestCase
         $this->assertEqualsWithDelta(50, $writes, 20);
 
         Route::get('/users-100', fn () => [])
-            ->middleware(Sample::rate(1));
+            ->middleware(Sample::always());
         $writes = 0;
 
         for ($i = 0; $i < 100; $i++) {
@@ -62,7 +62,7 @@ class SampleTest extends TestCase
     public function test_it_can_sample_unmatched_routes()
     {
         $ingest = $this->fakeIngest();
-        Route::fallback(fn () => abort(404))->middleware(Sample::rate(0));
+        Route::fallback(fn () => abort(404))->middleware(Sample::never());
 
         $writes = 0;
 
@@ -87,7 +87,7 @@ class SampleTest extends TestCase
 
         $this->assertEqualsWithDelta(50, $writes, 20);
 
-        Route::fallback(fn () => abort(404))->middleware(Sample::rate(1));
+        Route::fallback(fn () => abort(404))->middleware(Sample::always());
         $writes = 0;
 
         for ($i = 0; $i < 100; $i++) {

--- a/workbench/routes/web.php
+++ b/workbench/routes/web.php
@@ -48,7 +48,7 @@ Route::get('/', static function () {
 Route::get('/sampled-or-throw', static fn () => [])->middleware([
     // the order of these middleware matters
     'throwing-middleware',
-    Sample::rate(0),
+    Sample::never(),
 ]);
 
 Route::get('/test-exception', App\Http\ExceptionTestController::class);


### PR DESCRIPTION
This PR adds convenient aliases for the `Sample` middleware

- `Sample::always()` instead of `Sample::rate(1.0)`
- `Sample::never()` instead of `Sample::rate(0.0)`