### PR TITLE
Capture query connection name with read/write type

### DIFF
--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -45,7 +45,7 @@ final class QuerySensor
                 file: $file ?? '',
                 line: $line ?? 0,
                 duration: $durationInMicroseconds,
-                connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
+                connection: $event->connection->getNameWithReadWriteType() ?? '',
             ),
             function () use ($event, $record) {
                 $this->executionState->queries++;

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -352,4 +352,52 @@ class QuerySensorTest extends TestCase
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('query:0.connection', '');
     }
+
+    public function test_it_can_capture_connection_name_with_read_write_type()
+    {
+        $ingest = $this->fakeIngest();
+        $connection = new MySqlConnection('test', config: [
+            'name' => 'mysql',
+            'driver' => 'mysql',
+            'read' => [
+                'host' => [
+                    '192.168.1.1',
+                    '196.168.1.2',
+                ],
+            ],
+            'write' => [
+                'host' => [
+                    '196.168.1.3',
+                ],
+            ],
+            'sticky' => true,
+        ]);
+
+        // Without read/write type
+        Event::dispatch(new QueryExecuted('select * from users', [], 1, $connection));
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection', 'mysql');
+        $ingest->forgetWrites();
+
+        // With read type
+        $connection->setReadWriteType('read');
+
+        Event::dispatch(new QueryExecuted('select * from users', [], 1, $connection));
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection', 'mysql::read');
+        $ingest->forgetWrites();
+
+        // With write type
+        $connection->setReadWriteType('write');
+
+        Event::dispatch(new QueryExecuted('select * from users', [], 1, $connection));
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection', 'mysql::write');
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR enhances query collection by capturing the connection name along with its read/write type when read and write connections are configured.