### PR TITLE
Do not include bootstrapping or web worker initial wait time in first request for Octane

### DIFF
--- a/src/Hooks/OctaneListener.php
+++ b/src/Hooks/OctaneListener.php
@@ -10,8 +10,6 @@ use Throwable;
 
 class OctaneListener
 {
-    private bool $firstRequest = true;
-
     /**
      * @param  Core<RequestState|CommandState>  $nightwatch
      */
@@ -22,12 +20,6 @@ class OctaneListener
 
     public function __invoke(RequestReceived $event): void // @phpstan-ignore class.notFound
     {
-        if ($this->firstRequest) {
-            $this->firstRequest = false;
-
-            return;
-        }
-
         try {
             $this->nightwatch->prepareForNextRequest();
         } catch (Throwable $e) {


### PR DESCRIPTION
When using Octane, if a worker is started and then 30 seconds later the first request comes in, we show that the before middleware stage is 30s+.

This doesn't really reflect reality for Octane. A user is not waiting for Octane to bootstrap, unlike a non-Octane request where user's do wait while the framework bootstraps.

This PR removes bootstrapping time completely from the initial Octane request to each worker. We previously would only capture it for the first request. It also ensures that the before middleware phase starts when the first request comes in, not after the web worker has bootstrapped.