### PR TITLE
Capture query connection type (read or write)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": "^8.2",
+        "ext-pdo": "*",
         "ext-zlib": "*",
         "guzzlehttp/promises": "^2.0",
         "laravel/framework": "^10.0|^11.0|^12.0",
@@ -35,7 +36,6 @@
     },
     "require-dev": {
         "ext-pcntl": "*",
-        "ext-pdo": "*",
         "aws/aws-sdk-php": "^3.349",
         "guzzlehttp/guzzle": "^7.0",
         "guzzlehttp/psr7": "^2.0",

--- a/src/Records/Query.php
+++ b/src/Records/Query.php
@@ -4,13 +4,16 @@ namespace Laravel\Nightwatch\Records;
 
 final class Query
 {
+    /**
+     * @param  'read'|'write'|''  $connectionType
+     */
     public function __construct(
         public string $sql,
         public readonly string $file,
         public readonly int $line,
         public readonly int $duration,
         public readonly string $connection,
-        public readonly bool $usingReadConnection,
+        public readonly string $connectionType,
     ) {
         //
     }

--- a/src/Records/Query.php
+++ b/src/Records/Query.php
@@ -10,6 +10,7 @@ final class Query
         public readonly int $line,
         public readonly int $duration,
         public readonly string $connection,
+        public readonly bool $usingReadConnection,
     ) {
         //
     }

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nightwatch\Sensors;
 
+use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
 use Laravel\Nightwatch\Clock;
 use Laravel\Nightwatch\Location;
@@ -9,6 +10,7 @@ use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Laravel\Nightwatch\Types\Str;
+use PDO;
 
 use function hash;
 use function in_array;
@@ -46,6 +48,7 @@ final class QuerySensor
                 line: $line ?? 0,
                 duration: $durationInMicroseconds,
                 connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
+                usingReadConnection: $this->usingReadConnection($event),
             ),
             function () use ($event, $record) {
                 $this->executionState->queries++;
@@ -68,6 +71,7 @@ final class QuerySensor
                     'line' => $record->line,
                     'duration' => $record->duration,
                     'connection' => Str::tinyText($record->connection),
+                    'using_read_connection' => $record->usingReadConnection,
                 ];
             },
         ];
@@ -86,5 +90,26 @@ final class QuerySensor
         }
 
         return hash('xxh128', "{$record->connection},{$sql}");
+    }
+
+    /**
+     * Determine if the query was executed using the read connection.
+     */
+    private function usingReadConnection(QueryExecuted $event): bool
+    {
+        $connection = $event->connection;
+
+        $readPdo = $connection->getRawReadPdo();
+        $writePdo = $connection->getRawPdo();
+
+        if (! $readPdo instanceof PDO) {
+            return false;
+        }
+
+        if (! $writePdo instanceof PDO) {
+            return true;
+        }
+
+        return $connection->getReadPdo() !== $writePdo;
     }
 }

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -48,7 +48,7 @@ final class QuerySensor
                 line: $line ?? 0,
                 duration: $durationInMicroseconds,
                 connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
-                usingReadConnection: $this->usingReadConnection($event),
+                connectionType: $this->connectionType($event),
             ),
             function () use ($event, $record) {
                 $this->executionState->queries++;
@@ -71,7 +71,7 @@ final class QuerySensor
                     'line' => $record->line,
                     'duration' => $record->duration,
                     'connection' => Str::tinyText($record->connection),
-                    'using_read_connection' => $record->usingReadConnection,
+                    'connection_type' => $record->connectionType,
                 ];
             },
         ];
@@ -93,23 +93,32 @@ final class QuerySensor
     }
 
     /**
-     * Determine if the query was executed using the read connection.
+     * Get the read or write connection type if configured.
+     *
+     * @return 'read'|'write'|''
      */
-    private function usingReadConnection(QueryExecuted $event): bool
+    private function connectionType(QueryExecuted $event): string
     {
         $connection = $event->connection;
-
         $readPdo = $connection->getRawReadPdo();
         $writePdo = $connection->getRawPdo();
 
+        if ($readPdo === null) {
+            return '';
+        }
+
         if (! $readPdo instanceof PDO) {
-            return false;
+            return 'write';
         }
 
         if (! $writePdo instanceof PDO) {
-            return true;
+            return 'read';
         }
 
-        return $connection->getReadPdo() !== $writePdo;
+        if ($connection->getReadPdo() === $writePdo) {
+            return 'write';
+        }
+
+        return 'read';
     }
 }

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -48,7 +48,7 @@ final class QuerySensor
                 line: $line ?? 0,
                 duration: $durationInMicroseconds,
                 connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
-                connectionType: $this->connectionType($event),
+                connectionType: $this->connectionType($event) ?? '',
             ),
             function () use ($event, $record) {
                 $this->executionState->queries++;
@@ -95,16 +95,16 @@ final class QuerySensor
     /**
      * Get the read or write connection type if configured.
      *
-     * @return 'read'|'write'|''
+     * @return 'read'|'write'|null
      */
-    private function connectionType(QueryExecuted $event): string
+    private function connectionType(QueryExecuted $event): ?string
     {
         $connection = $event->connection;
         $readPdo = $connection->getRawReadPdo();
         $writePdo = $connection->getRawPdo();
 
         if ($readPdo === null) {
-            return '';
+            return null;
         }
 
         if (! $readPdo instanceof PDO) {

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -513,7 +513,7 @@ class QuerySensorTest extends TestCase
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('query:0.connection_type', 'read');
-        $ingest->assertLatestWrite('query:0.connection_type', 'write');
+        $ingest->assertLatestWrite('query:1.connection_type', 'write');
     }
 
     public function test_it_captures_connection_type_when_forgetting_modified_records_state()
@@ -533,7 +533,7 @@ class QuerySensorTest extends TestCase
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('query:0.connection_type', 'write');
-        $ingest->assertLatestWrite('query:0.connection_type', 'read');
+        $ingest->assertLatestWrite('query:1.connection_type', 'read');
     }
 
     private function configureReadWriteConnection(array $options = []): void

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -497,6 +497,45 @@ class QuerySensorTest extends TestCase
         $ingest->assertLatestWrite('query:0.connection_type', 'write');
     }
 
+    public function test_it_captures_write_connection_when_forcing_select_from_write_after_read_pdo_is_resolved()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::select('select 1');
+            DB::selectFromWriteConnection('select 1');
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', 'read');
+        $ingest->assertLatestWrite('query:0.connection_type', 'write');
+    }
+
+    public function test_it_captures_connection_type_when_forgetting_modified_records_state()
+    {
+        $this->configureReadWriteConnection(['sticky' => true]);
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::statement('select 1');
+            DB::forgetRecordModificationState();
+            DB::select('select 1');
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', 'write');
+        $ingest->assertLatestWrite('query:0.connection_type', 'read');
+    }
+
     private function configureReadWriteConnection(array $options = []): void
     {
         $connection = Config::get('database.default');

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -95,7 +95,7 @@ class QuerySensorTest extends TestCase
                 'line' => $line,
                 'duration' => 4321,
                 'connection' => $connection,
-                'using_read_connection' => false,
+                'connection_type' => '',
             ],
         ]);
     }
@@ -356,7 +356,7 @@ class QuerySensorTest extends TestCase
         $ingest->assertLatestWrite('query:0.connection', '');
     }
 
-    public function test_it_captures_using_read_connection_as_false_when_read_and_write_connections_are_not_configured()
+    public function test_it_captures_connection_type_as_empty_string_when_read_and_write_connections_are_not_configured()
     {
         $ingest = $this->fakeIngest();
 
@@ -368,10 +368,10 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+        $ingest->assertLatestWrite('query:0.connection_type', '');
     }
 
-    public function test_it_captures_using_read_connection_as_true_for_select_query()
+    public function test_it_captures_connection_type_as_read_for_select_query()
     {
         $this->configureReadWriteConnection();
 
@@ -385,10 +385,10 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', true);
+        $ingest->assertLatestWrite('query:0.connection_type', 'read');
     }
 
-    public function test_it_captures_using_read_connection_as_false_for_write_query()
+    public function test_it_captures_connection_type_as_write_for_write_query()
     {
         $this->configureReadWriteConnection();
 
@@ -406,10 +406,10 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+        $ingest->assertLatestWrite('query:0.connection_type', 'write');
     }
 
-    public function test_it_captures_using_read_connection_as_false_when_records_have_been_modified_and_sticky_connection_is_enabled()
+    public function test_it_captures_connection_type_as_write_when_records_have_been_modified_and_sticky_connection_is_enabled()
     {
         $this->configureReadWriteConnection(['sticky' => true]);
 
@@ -429,11 +429,11 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', false); // insert
-        $ingest->assertLatestWrite('query:1.using_read_connection', false); // select
+        $ingest->assertLatestWrite('query:0.connection_type', 'write'); // insert
+        $ingest->assertLatestWrite('query:1.connection_type', 'write'); // select
     }
 
-    public function test_it_captures_using_read_connection_as_false_for_insert_and_true_for_select_when_sticky_connection_is_disabled()
+    public function test_it_captures_connection_type_as_write_for_insert_and_read_for_select_when_sticky_connection_is_disabled()
     {
         $this->configureReadWriteConnection(['sticky' => false]);
 
@@ -453,11 +453,11 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', false); // insert
-        $ingest->assertLatestWrite('query:1.using_read_connection', true); // select
+        $ingest->assertLatestWrite('query:0.connection_type', 'write'); // insert
+        $ingest->assertLatestWrite('query:1.connection_type', 'read'); // select
     }
 
-    public function test_it_captures_using_read_connection_as_false_when_it_should_use_write_connection_when_reading()
+    public function test_it_captures_connection_type_as_write_when_it_should_use_write_connection_when_reading()
     {
         $this->configureReadWriteConnection();
 
@@ -471,10 +471,10 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+        $ingest->assertLatestWrite('query:0.connection_type', 'write');
     }
 
-    public function test_it_captures_using_read_connection_as_false_when_in_a_transaction()
+    public function test_it_captures_connection_type_as_write_when_in_a_transaction()
     {
         $this->configureReadWriteConnection();
 
@@ -494,7 +494,7 @@ class QuerySensorTest extends TestCase
 
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+        $ingest->assertLatestWrite('query:0.connection_type', 'write');
     }
 
     private function configureReadWriteConnection(array $options = []): void

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -21,9 +21,11 @@ use SingleStore\Laravel\Connect\Connection as LegacySingleStoreConnection;
 use SingleStore\Laravel\Connect\SingleStoreConnection;
 use Tests\TestCase;
 
+use function array_merge;
 use function base64_encode;
 use function class_exists;
 use function dirname;
+use function fake;
 use function hash;
 use function hex2bin;
 use function in_array;
@@ -93,6 +95,7 @@ class QuerySensorTest extends TestCase
                 'line' => $line,
                 'duration' => 4321,
                 'connection' => $connection,
+                'using_read_connection' => false,
             ],
         ]);
     }
@@ -351,5 +354,163 @@ class QuerySensorTest extends TestCase
 
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('query:0.connection', '');
+    }
+
+    public function test_it_captures_using_read_connection_as_false_when_read_and_write_connections_are_not_configured()
+    {
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+    }
+
+    public function test_it_captures_using_read_connection_as_true_for_select_query()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', true);
+    }
+
+    public function test_it_captures_using_read_connection_as_false_for_write_query()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::table('users')->insert([
+                'name' => fake()->name(),
+                'email' => fake()->email(),
+                'password' => fake()->password(),
+            ]);
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+    }
+
+    public function test_it_captures_using_read_connection_as_false_when_records_have_been_modified_and_sticky_connection_is_enabled()
+    {
+        $this->configureReadWriteConnection(['sticky' => true]);
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::table('users')->insert([
+                'name' => fake()->name(),
+                'email' => fake()->email(),
+                'password' => fake()->password(),
+            ]);
+
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', false); // insert
+        $ingest->assertLatestWrite('query:1.using_read_connection', false); // select
+    }
+
+    public function test_it_captures_using_read_connection_as_false_for_insert_and_true_for_select_when_sticky_connection_is_disabled()
+    {
+        $this->configureReadWriteConnection(['sticky' => false]);
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::table('users')->insert([
+                'name' => fake()->name(),
+                'email' => fake()->email(),
+                'password' => fake()->password(),
+            ]);
+
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', false); // insert
+        $ingest->assertLatestWrite('query:1.using_read_connection', true); // select
+    }
+
+    public function test_it_captures_using_read_connection_as_false_when_it_should_use_write_connection_when_reading()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::useWriteConnectionWhenReading()->table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+    }
+
+    public function test_it_captures_using_read_connection_as_false_when_in_a_transaction()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::beginTransaction();
+
+            $users = DB::table('users')->get();
+
+            DB::rollBack();
+
+            return $users;
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.using_read_connection', false);
+    }
+
+    private function configureReadWriteConnection(array $options = []): void
+    {
+        $connection = Config::get('database.default');
+        $config = Config::get("database.connections.{$connection}");
+
+        Config::set("database.connections.{$connection}", array_merge($config, [
+            'read' => [
+                'database' => $config['database'],
+            ],
+            'write' => [
+                'database' => $config['database'],
+            ],
+        ], $options));
+
+        DB::purge($connection);
     }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR updates `QuerySensor` to capture whether the query was executed using a read or write connection.
We capture this information only when the read and write connections are configured in the application.