### PR TITLE
Use ConfigRepository methods instead of directly accessing the raw internal array

### DIFF
--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -184,7 +184,7 @@ final class NightwatchServiceProvider extends ServiceProvider
 
         $this->config = $this->app->make(Repository::class);
 
-        $this->nightwatchConfig = $this->config->get('nightwatch', []);
+        $this->nightwatchConfig = (array) $this->config->get('nightwatch', []);
     }
 
     private function registerBindings(): void

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -184,7 +184,7 @@ final class NightwatchServiceProvider extends ServiceProvider
 
         $this->config = $this->app->make(Repository::class);
 
-        $this->nightwatchConfig = $this->config->all()['nightwatch'] ?? [];
+        $this->nightwatchConfig = $this->config->get('nightwatch', []);
     }
 
     private function registerBindings(): void
@@ -197,7 +197,7 @@ final class NightwatchServiceProvider extends ServiceProvider
 
     private function registerLogger(): void
     {
-        if (! isset($this->config->all()['logging']['channels']['nightwatch'])) {
+        if (! $this->config->has('logging.channels.nightwatch')) {
             $this->config->set('logging.channels.nightwatch', [
                 'driver' => 'custom',
                 'via' => Logger::class,


### PR DESCRIPTION
Uses the methods provided by the Config Repository to interact with the config data instead of directly accessing the raw internal array of data.

This fixes support for applications that might not store the config values in the exact internal array structure that we are expecting (i.e. Winter CMS, which stores everything under namespaced keys, where top level keys end up having "*::" prefixed to their key in the internal array.

The switch to accessing the raw array internals of the Config Repository occurred in https://github.com/laravel/nightwatch/commit/cd09cd021b29ab9d441521625b20a5cc933791ac#diff-f418488ec2f97353bcc9eaf797747e525178b3746278ca795966c7b0aea2c883L65-L302 and it appears to have unintentional side effects.

---

Without this change I'll have to do something truly horrible in Winter's `ConfigRepository`:

```php
public function all(): array
{
    // Work on a copy so we don't mutate $this->items
    $items = $this->items;

    // Add "alias" keys (foo) that reference "*::foo" when present
    foreach ($items as $key => &$value) {
        if (strncmp($key, '*::', 3) === 0) {
            $alias = substr($key, 3);
            if ($alias !== '' && !array_key_exists($alias, $items)) {
                $items[$alias] =& $value; // reference to the same element
            }
        }
    }
    unset($value); // break the reference from foreach

    return $items;
}
```