### PR TITLE
Allow multiple filter callbacks to be registered

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -198,8 +198,10 @@ trait CapturesState
     {
         [$record, $resolver] = $this->sensor->outgoingRequest($startMicrotime, $endMicrotime, $request, $response);
 
-        if ($this->rejectOutgoingRequestCallback && $this->ignore(fn () => ($this->rejectOutgoingRequestCallback)($record))) {
-            return;
+        foreach ($this->rejectOutgoingRequestCallbacks as $callback) {
+            if ($this->ignore(fn () => ($callback)($record))) {
+                return;
+            }
         }
 
         if ($this->redactOutgoingRequestCallback) {
@@ -223,8 +225,10 @@ trait CapturesState
 
         [$record, $resolver] = $this->sensor->query($event, $trace);
 
-        if ($this->rejectQueryCallback && $this->ignore(fn () => ($this->rejectQueryCallback)($record))) {
-            return;
+        foreach ($this->rejectQueryCallbacks as $callback) {
+            if ($this->ignore(fn () => ($callback)($record))) {
+                return;
+            }
         }
 
         if ($this->redactQueryCallback) {
@@ -251,8 +255,10 @@ trait CapturesState
 
         [$record, $resolver] = $queuedJob;
 
-        if ($this->rejectQueuedJobCallback && $this->ignore(fn () => ($this->rejectQueuedJobCallback)($record))) {
-            return;
+        foreach ($this->rejectQueuedJobCallbacks as $callback) {
+            if ($this->ignore(fn () => ($callback)($record))) {
+                return;
+            }
         }
 
         $this->ingest->write($resolver());
@@ -275,8 +281,10 @@ trait CapturesState
 
         [$record, $resolver] = $notification;
 
-        if ($this->rejectNotificationCallback && $this->ignore(fn () => ($this->rejectNotificationCallback)($record))) {
-            return;
+        foreach ($this->rejectNotificationCallbacks as $callback) {
+            if ($this->ignore(fn () => ($callback)($record))) {
+                return;
+            }
         }
 
         $this->ingest->write($resolver());
@@ -299,8 +307,10 @@ trait CapturesState
 
         [$record, $resolver] = $mail;
 
-        if ($this->rejectMailCallback && $this->ignore(fn () => ($this->rejectMailCallback)($record))) {
-            return;
+        foreach ($this->rejectMailCallbacks as $callback) {
+            if ($this->ignore(fn () => ($callback)($record))) {
+                return;
+            }
         }
 
         if ($this->redactMailCallback) {
@@ -327,8 +337,10 @@ trait CapturesState
 
         [$record, $resolver] = $cacheEvent;
 
-        if ($this->rejectCacheEventCallback && $this->ignore(fn () => ($this->rejectCacheEventCallback)($record))) {
-            return;
+        foreach ($this->rejectCacheEventCallbacks as $callback) {
+            if ($this->ignore(fn () => ($callback)($record))) {
+                return;
+            }
         }
 
         if ($this->redactCacheEventCallback) {

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -199,7 +199,7 @@ trait CapturesState
         [$record, $resolver] = $this->sensor->outgoingRequest($startMicrotime, $endMicrotime, $request, $response);
 
         foreach ($this->rejectOutgoingRequestCallbacks as $callback) {
-            if ($this->ignore(fn () => ($callback)($record))) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
                 return;
             }
         }
@@ -226,7 +226,7 @@ trait CapturesState
         [$record, $resolver] = $this->sensor->query($event, $trace);
 
         foreach ($this->rejectQueryCallbacks as $callback) {
-            if ($this->ignore(fn () => ($callback)($record))) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
                 return;
             }
         }
@@ -256,7 +256,7 @@ trait CapturesState
         [$record, $resolver] = $queuedJob;
 
         foreach ($this->rejectQueuedJobCallbacks as $callback) {
-            if ($this->ignore(fn () => ($callback)($record))) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
                 return;
             }
         }
@@ -282,7 +282,7 @@ trait CapturesState
         [$record, $resolver] = $notification;
 
         foreach ($this->rejectNotificationCallbacks as $callback) {
-            if ($this->ignore(fn () => ($callback)($record))) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
                 return;
             }
         }
@@ -308,7 +308,7 @@ trait CapturesState
         [$record, $resolver] = $mail;
 
         foreach ($this->rejectMailCallbacks as $callback) {
-            if ($this->ignore(fn () => ($callback)($record))) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
                 return;
             }
         }
@@ -338,7 +338,7 @@ trait CapturesState
         [$record, $resolver] = $cacheEvent;
 
         foreach ($this->rejectCacheEventCallbacks as $callback) {
-            if ($this->ignore(fn () => ($callback)($record))) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
                 return;
             }
         }

--- a/src/Concerns/RejectsRecords.php
+++ b/src/Concerns/RejectsRecords.php
@@ -12,34 +12,34 @@ use Laravel\Nightwatch\Records\QueuedJob;
 trait RejectsRecords
 {
     /**
-     * @var ?callable(CacheEvent): bool
+     * @var array<callable(CacheEvent): bool>
      */
-    private $rejectCacheEventCallback = null;
+    private $rejectCacheEventCallbacks = [];
 
     /**
-     * @var ?callable(Mail): bool
+     * @var array<callable(Mail): bool>
      */
-    private $rejectMailCallback = null;
+    private $rejectMailCallbacks = [];
 
     /**
-     * @var ?callable(Notification): bool
+     * @var array<callable(Notification): bool>
      */
-    private $rejectNotificationCallback = null;
+    private $rejectNotificationCallbacks = [];
 
     /**
-     * @var ?callable(OutgoingRequest): bool
+     * @var array<callable(OutgoingRequest): bool>
      */
-    private $rejectOutgoingRequestCallback = null;
+    private $rejectOutgoingRequestCallbacks = [];
 
     /**
-     * @var ?callable(Query): bool
+     * @var array<callable(Query): bool>
      */
-    private $rejectQueryCallback = null;
+    private $rejectQueryCallbacks = [];
 
     /**
-     * @var ?callable(QueuedJob): bool
+     * @var array<callable(QueuedJob): bool>
      */
-    private $rejectQueuedJobCallback = null;
+    private $rejectQueuedJobCallbacks = [];
 
     /**
      * @api
@@ -48,7 +48,7 @@ trait RejectsRecords
      */
     public function rejectCacheEvents(callable $callback): void
     {
-        $this->rejectCacheEventCallback = $callback;
+        $this->rejectCacheEventCallbacks[] = $callback;
     }
 
     /**
@@ -58,7 +58,7 @@ trait RejectsRecords
      */
     public function rejectMail(callable $callback): void
     {
-        $this->rejectMailCallback = $callback;
+        $this->rejectMailCallbacks[] = $callback;
     }
 
     /**
@@ -68,7 +68,7 @@ trait RejectsRecords
      */
     public function rejectNotifications(callable $callback): void
     {
-        $this->rejectNotificationCallback = $callback;
+        $this->rejectNotificationCallbacks[] = $callback;
     }
 
     /**
@@ -78,7 +78,7 @@ trait RejectsRecords
      */
     public function rejectOutgoingRequests(callable $callback): void
     {
-        $this->rejectOutgoingRequestCallback = $callback;
+        $this->rejectOutgoingRequestCallbacks[] = $callback;
     }
 
     /**
@@ -88,7 +88,7 @@ trait RejectsRecords
      */
     public function rejectQueries(callable $callback): void
     {
-        $this->rejectQueryCallback = $callback;
+        $this->rejectQueryCallbacks[] = $callback;
     }
 
     /**
@@ -98,6 +98,6 @@ trait RejectsRecords
      */
     public function rejectQueuedJobs(callable $callback): void
     {
-        $this->rejectQueuedJobCallback = $callback;
+        $this->rejectQueuedJobCallbacks[] = $callback;
     }
 }

--- a/src/Concerns/RejectsRecords.php
+++ b/src/Concerns/RejectsRecords.php
@@ -12,34 +12,34 @@ use Laravel\Nightwatch\Records\QueuedJob;
 trait RejectsRecords
 {
     /**
-     * @var array<callable(CacheEvent): bool>
+     * @var list<callable(CacheEvent): bool>
      */
-    private $rejectCacheEventCallbacks = [];
+    private array $rejectCacheEventCallbacks = [];
 
     /**
-     * @var array<callable(Mail): bool>
+     * @var list<callable(Mail): bool>
      */
-    private $rejectMailCallbacks = [];
+    private array $rejectMailCallbacks = [];
 
     /**
-     * @var array<callable(Notification): bool>
+     * @var list<callable(Notification): bool>
      */
-    private $rejectNotificationCallbacks = [];
+    private array $rejectNotificationCallbacks = [];
 
     /**
-     * @var array<callable(OutgoingRequest): bool>
+     * @var list<callable(OutgoingRequest): bool>
      */
-    private $rejectOutgoingRequestCallbacks = [];
+    private array $rejectOutgoingRequestCallbacks = [];
 
     /**
-     * @var array<callable(Query): bool>
+     * @var list<callable(Query): bool>
      */
-    private $rejectQueryCallbacks = [];
+    private array $rejectQueryCallbacks = [];
 
     /**
-     * @var array<callable(QueuedJob): bool>
+     * @var list<callable(QueuedJob): bool>
      */
-    private $rejectQueuedJobCallbacks = [];
+    private array $rejectQueuedJobCallbacks = [];
 
     /**
      * @api

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -66,12 +66,12 @@ class FilteringTest extends TestCase
     public function test_it_can_filter_queries(): void
     {
         $ingest = $this->fakeIngest();
-        Nightwatch::rejectQueries(function (Query $query) {
-            return str_contains($query->sql, 'jobs');
-        });
+        Nightwatch::rejectQueries(fn (Query $query) => str_contains($query->sql, 'jobs'));
+        Nightwatch::rejectQueries(fn (Query $query) => str_contains($query->sql, 'sessions'));
 
         DB::statement('select * from users');
         DB::statement('select * from jobs');
+        DB::statement('select * from sessions');
         $ingest->digest();
 
         $ingest->assertWrittenTimes(1);
@@ -121,11 +121,12 @@ class FilteringTest extends TestCase
     public function test_it_can_filter_notifications(): void
     {
         $ingest = $this->fakeIngest();
-        $keep = [false, true];
-        Nightwatch::rejectNotifications(function (NotificationRecord $notification) use (&$keep) {
-            return array_shift($keep);
+        $reject = [true, true, false];
+        Nightwatch::rejectNotifications(function (NotificationRecord $notification) use (&$reject) {
+            return array_shift($reject);
         });
 
+        Notification::route('mail', 'phillip@laravel.com')->notify(new MyNotification);
         Notification::route('mail', 'phillip@laravel.com')->notify(new MyNotification);
         Notification::route('mail', 'phillip@laravel.com')->notify(new MyNotification);
         $ingest->digest();
@@ -161,11 +162,11 @@ class FilteringTest extends TestCase
     public function test_it_can_filter_mail(): void
     {
         $ingest = $this->fakeIngest();
-        Nightwatch::rejectMail(function (MailRecord $mail) {
-            return $mail->subject === 'Hello Laravel';
-        });
+        Nightwatch::rejectMail(fn (MailRecord $mail) => $mail->subject === 'Hello Laravel');
+        Nightwatch::rejectMail(fn (MailRecord $mail) => $mail->subject === 'Hello Cloud');
 
         Mail::to('tim@laravel.com')->send(new MyMail('Hello Laravel'));
+        Mail::to('tim@laravel.com')->send(new MyMail('Hello Cloud'));
         Mail::to('tim@laravel.com')->send(new MyMail('Hello Nightwatch'));
         $ingest->digest();
 
@@ -200,12 +201,12 @@ class FilteringTest extends TestCase
     public function test_it_can_filter_cache_events(): void
     {
         $ingest = $this->fakeIngest();
-        Nightwatch::rejectCacheEvents(function (CacheEvent $cacheEvent) {
-            return str_contains($cacheEvent->key, 'forget');
-        });
+        Nightwatch::rejectCacheEvents(fn (CacheEvent $cacheEvent) => str_contains($cacheEvent->key, 'forget'));
+        Nightwatch::rejectCacheEvents(fn (CacheEvent $cacheEvent) => str_contains($cacheEvent->key, 'remember'));
 
         Cache::get('keep');
         Cache::get('forget');
+        Cache::get('remember');
         $ingest->digest();
 
         $ingest->assertWrittenTimes(1);
@@ -244,14 +245,15 @@ class FilteringTest extends TestCase
     {
         $ingest = $this->fakeIngest();
         Http::fake([
-            'https://nightwatch.laravel.com' => Http::response(status: 200),
             'https://laravel.com' => Http::response(status: 200),
+            'https://laravel.cloud' => Http::response(status: 200),
+            'https://nightwatch.laravel.com' => Http::response(status: 200),
         ]);
-        Nightwatch::rejectOutgoingRequests(function (OutgoingRequest $outgoingRequest) {
-            return $outgoingRequest->url === 'https://nightwatch.laravel.com';
-        });
+        Nightwatch::rejectOutgoingRequests(fn (OutgoingRequest $outgoingRequest) => $outgoingRequest->url === 'https://laravel.cloud');
+        Nightwatch::rejectOutgoingRequests(fn (OutgoingRequest $outgoingRequest) => $outgoingRequest->url === 'https://nightwatch.laravel.com');
 
         Http::get('https://laravel.com');
+        Http::get('https://laravel.cloud');
         Http::get('https://nightwatch.laravel.com');
         $ingest->digest();
 


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Currently, calling `Nightwatch::rejectXXXCallbacks` multiple times overrides the previously registered callback.
This PR allows multiple filter callbacks to be registered.