### PR TITLE
Use config dot notation

### DIFF
--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -184,7 +184,7 @@ final class NightwatchServiceProvider extends ServiceProvider
 
         $this->config = $this->app->make(Repository::class);
 
-        $this->nightwatchConfig = $this->config->all()['nightwatch'] ?? [];
+        $this->nightwatchConfig = $this->config->get('nightwatch') ?? [];
     }
 
     private function registerBindings(): void
@@ -197,7 +197,7 @@ final class NightwatchServiceProvider extends ServiceProvider
 
     private function registerLogger(): void
     {
-        if (! isset($this->config->all()['logging']['channels']['nightwatch'])) {
+        if (! $this->config->has('logging.channels.nightwatch')) {
             $this->config->set('logging.channels.nightwatch', [
                 'driver' => 'custom',
                 'via' => Logger::class,

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -184,7 +184,7 @@ final class NightwatchServiceProvider extends ServiceProvider
 
         $this->config = $this->app->make(Repository::class);
 
-        $this->nightwatchConfig = $this->config->get('nightwatch') ?? [];
+        $this->nightwatchConfig = $this->config->get('nightwatch') ?? []; // @phpstan-ignore assign.propertyType
     }
 
     private function registerBindings(): void

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -309,7 +309,7 @@ final class SensorManager
         $sensor = $this->queuedJobSensor ??= new QueuedJobSensor(
             executionState: $this->executionState,
             clock: $this->clock,
-            connectionConfig: $this->config->get('queue.connections') ?? [],
+            connectionConfig: $this->config->get('queue.connections') ?? [], // @phpstan-ignore argument.type
         );
 
         return $sensor($event);
@@ -323,7 +323,7 @@ final class SensorManager
         $sensor = $this->jobAttemptSensor ??= new JobAttemptSensor(
             commandState: $this->executionState, // @phpstan-ignore argument.type
             clock: $this->clock,
-            connectionConfig: $this->config->get('queue.connections') ?? [],
+            connectionConfig: $this->config->get('queue.connections') ?? [], // @phpstan-ignore argument.type
         );
 
         return $sensor($event);

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -309,7 +309,7 @@ final class SensorManager
         $sensor = $this->queuedJobSensor ??= new QueuedJobSensor(
             executionState: $this->executionState,
             clock: $this->clock,
-            connectionConfig: $this->config->all()['queue']['connections'] ?? [],
+            connectionConfig: $this->config->get('queue.connections') ?? [],
         );
 
         return $sensor($event);
@@ -323,7 +323,7 @@ final class SensorManager
         $sensor = $this->jobAttemptSensor ??= new JobAttemptSensor(
             commandState: $this->executionState, // @phpstan-ignore argument.type
             clock: $this->clock,
-            connectionConfig: $this->config->all()['queue']['connections'] ?? [],
+            connectionConfig: $this->config->get('queue.connections') ?? [],
         );
 
         return $sensor($event);


### PR DESCRIPTION
We have had reports that some systems, such as Winter CMS, do not support getting configuration using `Config::all()`, as they modify the storage format.

This moves to using dot notation when retrieving configuration from the config bag.