### PR TITLE
Set a sensible default for `NIGHTWATCH_DEPLOY`.

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -3,7 +3,7 @@
 return [
     'enabled' => env('NIGHTWATCH_ENABLED', true),
     'token' => env('NIGHTWATCH_TOKEN'),
-    'deployment' => env('NIGHTWATCH_DEPLOY'),
+    'deployment' => env('NIGHTWATCH_DEPLOY', rescue(static fn () => trim((string) shell_exec('git describe --tags --always 2>/dev/null')), '', false)),
     'server' => env('NIGHTWATCH_SERVER', (string) gethostname()),
     'capture_exception_source_code' => env('NIGHTWATCH_CAPTURE_EXCEPTION_SOURCE_CODE', true),
     'redact_headers' => explode(',', env('NIGHTWATCH_REDACT_HEADERS', 'Authorization,Cookie,Proxy-Authorization,X-XSRF-TOKEN')),

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Laravel\Nightwatch\ExecutionStage;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Orchestra\Testbench\Attributes\WithEnv;
@@ -15,6 +16,7 @@ use Tests\TestCase;
 
 use function dirname;
 use function hash;
+use function trim;
 
 class CoreTest extends TestCase
 {
@@ -88,5 +90,19 @@ class CoreTest extends TestCase
                 'laravel_version' => '11.33.0',
             ],
         ]);
+    }
+
+    #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]
+    public function test_it_uses_git_refs_for_deployments_by_default(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/test', function () {
+            return 'OK';
+        });
+
+        $this->get('/test')->assertOk();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('request:0.deploy', trim(`git describe --tags --always`));
     }
 }


### PR DESCRIPTION
This PR sets a sensible default for the `NIGHTWATCH_DEPLOY` configuration option.

It will attempt to get a human-friendly tag from git, and will fall back to getting a short hash.

Examples:

* `v1.15.2` - Exact tag match
* `v1.15.2-1-g2451327` - Changes have been committed since last tag
* `2fd2adb` - No tag available

If `git` or `shell_exec` is not available, it will safely fall back to an empty string.

There is a performance implication from running these commands, but this is solved by config caching which should always be performed on production systems.