### PR TITLE
Add ability to redact exceptions

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -177,7 +177,13 @@ trait CapturesState
                     $this->ingest->writeNow($this->sensor->fatalError($e));
                 }
             } else {
-                $this->ingest->write($this->sensor->exception($e, $handled));
+                [$record, $resolver] = $this->sensor->exception($e, $handled);
+
+                foreach ($this->redactExceptionCallbacks as $callback) {
+                    $this->ignore(static fn () => ($callback)($record));
+                }
+
+                $this->ingest->write($resolver());
             }
         } catch (Throwable $e) {
             Nightwatch::unrecoverableExceptionOccurred($e);

--- a/src/Concerns/RedactsRecords.php
+++ b/src/Concerns/RedactsRecords.php
@@ -4,6 +4,7 @@ namespace Laravel\Nightwatch\Concerns;
 
 use Laravel\Nightwatch\Records\CacheEvent;
 use Laravel\Nightwatch\Records\Command;
+use Laravel\Nightwatch\Records\Exception;
 use Laravel\Nightwatch\Records\Mail;
 use Laravel\Nightwatch\Records\OutgoingRequest;
 use Laravel\Nightwatch\Records\Query;
@@ -11,6 +12,11 @@ use Laravel\Nightwatch\Records\Request;
 
 trait RedactsRecords
 {
+    /**
+     * @var list<callable(Exception): bool>
+     */
+    private array $redactExceptionCallbacks = [];
+
     /**
      * @var list<callable(CacheEvent): bool>
      */
@@ -40,6 +46,16 @@ trait RedactsRecords
      * @var list<callable(Request): bool>
      */
     private array $redactRequestCallbacks = [];
+
+    /**
+     * @api
+     *
+     * @param  callable(Exception): bool  $callback
+     */
+    public function redactExceptions(callable $callback): void
+    {
+        $this->redactExceptionCallbacks[] = $callback;
+    }
 
     /**
      * @api

--- a/src/Records/Exception.php
+++ b/src/Records/Exception.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\Nightwatch\Records;
+
+final class Exception
+{
+    public function __construct(
+        public readonly string $class,
+        public string $message,
+        public readonly int|string $code,
+        public readonly string $file,
+        public readonly ?int $line,
+        public readonly bool $handled,
+    ) {
+        //
+    }
+}

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -20,6 +20,7 @@ use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Laravel\Nightwatch\Records\CacheEvent as CacheEventRecord;
 use Laravel\Nightwatch\Records\Command;
+use Laravel\Nightwatch\Records\Exception;
 use Laravel\Nightwatch\Records\Mail;
 use Laravel\Nightwatch\Records\Notification;
 use Laravel\Nightwatch\Records\OutgoingRequest;
@@ -63,7 +64,7 @@ final class SensorManager
     public $cacheEventSensor;
 
     /**
-     * @var (callable(Throwable, null|bool): array<mixed>)|null
+     * @var (callable(Throwable, null|bool): array{0: Exception, 1: callable(): array<mixed>})|null
      */
     public $exceptionSensor;
 
@@ -248,7 +249,7 @@ final class SensorManager
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: Exception, 1: callable(): array<mixed>}
      */
     public function exception(Throwable $e, ?bool $handled): array
     {

--- a/src/Sensors/ExceptionSensor.php
+++ b/src/Sensors/ExceptionSensor.php
@@ -7,6 +7,7 @@ use Illuminate\View\ViewException;
 use Laravel\Nightwatch\Clock;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Location;
+use Laravel\Nightwatch\Records\Exception;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Laravel\Nightwatch\Types\Str;
@@ -52,7 +53,7 @@ final class ExceptionSensor
     }
 
     /**
-     * @return array<mixed>
+     * @return array{0: Exception, 1: callable(): array<mixed>}
      */
     public function __invoke(Throwable $e, ?bool $handled): array
     {
@@ -73,30 +74,42 @@ final class ExceptionSensor
             $this->executionState->exceptionPreview = $normalizedException->getMessage();
         }
 
-        $this->executionState->exceptions++;
-
         return [
-            'v' => 3,
-            't' => 'exception',
-            'timestamp' => $nowMicrotime,
-            'deploy' => $this->executionState->deploy,
-            'server' => $this->executionState->server,
-            '_group' => hash('xxh128', $normalizedException::class.','.$normalizedException->getCode().','.$file.','.$line),
-            'trace_id' => $this->executionState->trace,
-            'execution_source' => $this->executionState->source,
-            'execution_id' => $this->executionState->id(),
-            'execution_preview' => $this->executionState->executionPreview(),
-            'execution_stage' => $this->executionState->stage,
-            'user' => $this->executionState->user->id(),
-            'class' => Str::tinyText($normalizedException::class),
-            'file' => Str::tinyText($file),
-            'line' => $line ?? 0,
-            'message' => Str::text($normalizedException->getMessage()),
-            'code' => (string) $normalizedException->getCode(),
-            'trace' => Str::mediumText($this->serializeTrace($normalizedException)),
-            'handled' => $handled,
-            'php_version' => $this->executionState->phpVersion,
-            'laravel_version' => $this->executionState->laravelVersion,
+            $record = new Exception(
+                class: $normalizedException::class,
+                message: $normalizedException->getMessage(),
+                code: $normalizedException->getCode(),
+                file: $file,
+                line: $line,
+                handled: $handled,
+            ),
+            function () use ($nowMicrotime, $record, $normalizedException) {
+                $this->executionState->exceptions++;
+
+                return [
+                    'v' => 3,
+                    't' => 'exception',
+                    'timestamp' => $nowMicrotime,
+                    'deploy' => $this->executionState->deploy,
+                    'server' => $this->executionState->server,
+                    '_group' => hash('xxh128', $record->class.','.$record->code.','.$record->file.','.$record->line),
+                    'trace_id' => $this->executionState->trace,
+                    'execution_source' => $this->executionState->source,
+                    'execution_id' => $this->executionState->id(),
+                    'execution_preview' => $this->executionState->executionPreview(),
+                    'execution_stage' => $this->executionState->stage,
+                    'user' => $this->executionState->user->id(),
+                    'class' => Str::tinyText($record->class),
+                    'file' => Str::tinyText($record->file),
+                    'line' => $record->line ?? 0,
+                    'message' => Str::text($record->message),
+                    'code' => (string) $record->code,
+                    'trace' => Str::mediumText($this->serializeTrace($normalizedException)),
+                    'handled' => $record->handled,
+                    'php_version' => $this->executionState->phpVersion,
+                    'laravel_version' => $this->executionState->laravelVersion,
+                ];
+            },
         ];
     }
 

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -19,6 +19,7 @@ use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Records\CacheEvent;
 use Laravel\Nightwatch\Records\Command;
+use Laravel\Nightwatch\Records\Exception;
 use Laravel\Nightwatch\Records\Mail as MailRecord;
 use Laravel\Nightwatch\Records\Notification as NotificationRecord;
 use Laravel\Nightwatch\Records\OutgoingRequest;
@@ -687,6 +688,23 @@ class FilteringTest extends TestCase
 
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('query:0.sql', 'select * from users where email = "***@***" or password = "***"');
+    }
+
+    public function test_it_can_redact_exceptions(): void
+    {
+        $ingest = $this->fakeIngest();
+        Nightwatch::redactExceptions(function (Exception $exception) {
+            $exception->message = str_replace('jess@laravel.com', '***@***', $exception->message);
+        });
+        Nightwatch::redactExceptions(function (Exception $exception) {
+            $exception->message = str_replace('secret', '***', $exception->message);
+        });
+
+        report(new RuntimeException('Error in query: select * from users where email = "jess@laravel.com" or password = "secret"'));
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('exception:0.message', 'Error in query: select * from users where email = "***@***" or password = "***"');
     }
 
     public function test_it_can_redact_requests(): void

--- a/tests/Unit/Hooks/GuzzleMiddlewareTest.php
+++ b/tests/Unit/Hooks/GuzzleMiddlewareTest.php
@@ -17,7 +17,7 @@ class GuzzleMiddlewareTest extends TestCase
         $this->core->sensor->exceptionSensor = function ($e) use (&$exceptions): array {
             $exceptions[] = $e;
 
-            return [];
+            return [[], fn () => []];
         };
         $thrownInMicrotimeResolver = false;
         $this->core->clock->microtimeResolver = function () use (&$thrownInMicrotimeResolver): float {

--- a/tests/Unit/SamplingTest.php
+++ b/tests/Unit/SamplingTest.php
@@ -224,7 +224,7 @@ class SamplingTest extends TestCase
     {
         $ingest = $this->fakeIngest();
         $this->core->config['sampling']['requests'] = 0;
-        $this->core->sensor->exceptionSensor = fn () => [];
+        $this->core->sensor->exceptionSensor = fn () => [[], fn () => []];
         $exception = new RuntimeException('Whoops!');
         Route::get('/users', fn () => throw $exception);
 


### PR DESCRIPTION
Expanding on #203, this PR adds a `redactExceptions` method that allows for exception messages to be redacted before ingestion.

```php
use Laravel\Nightwatch\Facades\Nightwatch;
use Laravel\Nightwatch\Records\Exception;

Nightwatch::redactExceptions(function (Exception $exception) {
    $exception->message = str_replace('secret', '***', $exception->message);
});
```

This does not currently support redacting `FatalError` exceptions in order to keep the memory and time impact as small as possible in OOM and timeout scenarios. I'm not currently aware of any `FatalError` exceptions that would contain sensitive information.