### PR TITLE
Update LogHandler.php

### DIFF
--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -58,7 +58,7 @@ final class LogHandler implements HandlerInterface
 
             $this->nightwatch->log($record);
 
-            return true;
+            return false;
         } catch (Throwable $e) {
             $this->nightwatch->report($e, handled: true);
 


### PR DESCRIPTION
Today if a log is handled successfully by Nightwatch it doesn't bubble the logs to further channels in the stack. 

In it's current state, Nightwatch will not allow logs to bubble to `webhook` because of it's position in the stack. This means that the order in a `.env`  _really_ matters.
```
LOG_STACK=single,nightwatch,webhook
```
