### PR TITLE
Fix requiring lowest dependencies in CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -116,7 +116,10 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true


### PR DESCRIPTION
Composer 2.9 introduced a new security feature that is on by default. If a package has a known security vulnerability it cannot be installed.

That was causing issues with our CI when we use the `--prefer-lowest` flag.

We now ignore this new feature for the package itself.

https://blog.packagist.com/composer-2-9/