### PR TITLE
Scheduled task sampling passthrough

### DIFF
--- a/src/Hooks/CommandStartingListener.php
+++ b/src/Hooks/CommandStartingListener.php
@@ -18,10 +18,13 @@ use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Queue\Events\Looping;
 use Illuminate\Queue\Events\WorkerStopping;
+use Illuminate\Support\Env;
 use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\State\CommandState;
 use Throwable;
+
+use function floatval;
 
 /**
  * @internal
@@ -116,6 +119,10 @@ final class CommandStartingListener
         }
 
         $this->nightwatch->configureGlobalCommandSampling();
+
+        $currentSample = $this->nightwatch->sampling() ? '1' : '0';
+        $sampling = (string) Env::get('NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED', $currentSample);
+        $this->nightwatch->sample(floatval($sampling));
 
         $this->nightwatch->prepareForCommand($event->command);
 

--- a/src/Hooks/ScheduledTaskStartingListener.php
+++ b/src/Hooks/ScheduledTaskStartingListener.php
@@ -7,6 +7,8 @@ use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
 use Throwable;
 
+use function sprintf;
+
 /**
  * @internal
  */
@@ -23,10 +25,19 @@ final class ScheduledTaskStartingListener
 
     public function __invoke(ScheduledTaskStarting $event): void
     {
+        $this->configureSamplingForEvent($event);
+
         try {
             $this->nightwatch->prepareForNextScheduledTask();
         } catch (Throwable $e) {
             $this->nightwatch->report($e, handled: true);
         }
+    }
+
+    protected function configureSamplingForEvent(ScheduledTaskStarting $event): void
+    {
+        $sampling = $this->nightwatch->sampling();
+
+        $event->task->command = sprintf('NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED=%d %s', $sampling, $event->task->command);
     }
 }

--- a/tests/Unit/Hooks/CommandStartingListenerTest.php
+++ b/tests/Unit/Hooks/CommandStartingListenerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Support\Env;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Hooks\CommandStartingListener;
 use Symfony\Component\Console\Input\StringInput;
@@ -90,5 +91,54 @@ class CommandStartingListenerTest extends TestCase
         $listener($event);
 
         $this->assertSame(0, $this->core->executionState->exceptions);
+    }
+
+    public function test_it_sets_default_sampling_when_no_environment(): void
+    {
+        $event = new CommandStarting('app:command', new StringInput(''), new NullOutput);
+        $events = $this->app[Dispatcher::class];
+        $kernel = $this->app[Kernel::class];
+
+        Nightwatch::sample();
+
+        $listener = new CommandStartingListener($events, $this->core, $kernel);
+        $listener($event);
+
+        $this->assertTrue(Nightwatch::sampling());
+
+        // TODO: how to rebind nightwatch and override config to set not sampling to assert against
+        Nightwatch::dontSample();
+
+        $listener = new CommandStartingListener($events, $this->core, $kernel);
+        $listener($event);
+
+        $this->assertFalse(Nightwatch::sampling());
+    }
+
+    public function test_it_sets_sampling_from_environment(): void
+    {
+        $event = new CommandStarting('app:command', new StringInput(''), new NullOutput);
+        $events = $this->app[Dispatcher::class];
+        $kernel = $this->app[Kernel::class];
+
+        $listener = new CommandStartingListener($events, $this->core, $kernel);
+        $listener($event);
+
+        $this->assertTrue(Nightwatch::sampling());
+    }
+
+    public function test_it_sets_not_sampling_from_environment(): void
+    {
+        $event = new CommandStarting('app:command', new StringInput(''), new NullOutput);
+        $events = $this->app[Dispatcher::class];
+        $kernel = $this->app[Kernel::class];
+
+        Env::getRepository()->set('NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED', '0');
+
+        $listener = new CommandStartingListener($events, $this->core, $kernel);
+        $listener($event);
+
+        $this->assertFalse(Nightwatch::sampling());
+        Env::getRepository()->clear('NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED');
     }
 }

--- a/tests/Unit/Hooks/ScheduledTaskStartingListenerTest.php
+++ b/tests/Unit/Hooks/ScheduledTaskStartingListenerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Unit\Hooks;
 use Illuminate\Console\Events\ScheduledTaskStarting;
 use Illuminate\Console\Scheduling\Schedule;
 use Laravel\Nightwatch\Clock;
+use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Hooks\ScheduledTaskStartingListener;
 use RuntimeException;
 use Tests\TestCase;
@@ -38,5 +39,29 @@ class ScheduledTaskStartingListenerTest extends TestCase
 
         $this->assertTrue($thrownInMicrotimeResolver);
         $this->assertSame(1, $this->core->executionState->exceptions);
+    }
+
+    public function test_it_prepends_sample_env_to_command(): void
+    {
+        $cmd = $this->app[Schedule::class]->command('php artisan inspire');
+        $event = new ScheduledTaskStarting($cmd);
+
+        $handler = new ScheduledTaskStartingListener($this->core);
+        $handler($event);
+
+        $this->assertStringStartsWith('NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED=1', $cmd->command);
+    }
+
+    public function test_it_prepends_no_sample_env_to_command(): void
+    {
+        Nightwatch::dontSample();
+
+        $cmd = $this->app[Schedule::class]->command('php artisan inspire');
+        $event = new ScheduledTaskStarting($cmd);
+
+        $handler = new ScheduledTaskStartingListener($this->core);
+        $handler($event);
+
+        $this->assertStringStartsWith('NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED=0', $cmd->command);
     }
 }


### PR DESCRIPTION
This is a first pass at adding support to propagate the Nightwatch sampling flag through from scheduled tasks to commands. Ie from `schedule:run` through to an artisan command that is runs on a schedule through the Symfony Process module.

Environment variables are the only reliable option we have to pass information from the parent schedule process through to the child command.

## How

This adds extra logic to the existing event listeners to:

1. Prepend a Nightwatch environment variable to the command string containing the current evaluated sampling value before starting a process for the command,
2. Pull that value from the environment and configuring Nightwatch before running the command.

The environment variable, if present, is used to determine whether the command is sampled. The sample rate is not passed down as it is left to the parent process to determine the likelihood of sampling and simply pass the flag down.  
This works well for scheduled tasks that invoke an artisan command as they will always have the environment variable passed (when updating to this version).  
A standard/manually run artisan command will not have the environment variable and will default to the global command sample rate configured.

There are also a few pieces to nail down:

1. What name do we want for the environment variable? Currently it is `NIGHTWATCH_SCHEDULE_TASK_SUBCOMMAND_SAMPLED`. I'm having trouble with the tense of schedule and sampled, or something entirely different.
2. I'm not how to add an extra test for when the environment variable is not present and it should fall back to the global/default config.
