### PR TITLE
Ignore `schedule:finish` command

### DIFF
--- a/src/Hooks/CommandStartingListener.php
+++ b/src/Hooks/CommandStartingListener.php
@@ -53,6 +53,7 @@ final class CommandStartingListener
             match ($event->command) {
                 'queue:work', 'queue:listen', 'horizon:work', 'vapor:work' => $this->registerJobHooks($event),
                 'schedule:run', 'schedule:work' => $this->registerScheduledTaskHooks(),
+                'schedule:finish' => null,
                 default => $this->registerCommandHooks($event),
             };
         } catch (Throwable $e) {

--- a/tests/Feature/Sensors/CommandSensorTest.php
+++ b/tests/Feature/Sensors/CommandSensorTest.php
@@ -274,6 +274,17 @@ class CommandSensorTest extends TestCase
         $ingest->assertLatestWrite('command:0.cache_events', 1);
         $ingest->assertLatestWrite('cache-event:0.execution_stage', 'action');
     }
+
+    public function test_it_ignores_schedule_finish_command(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $status = Artisan::handle($input = new StringInput('schedule:finish 123'));
+        Artisan::terminate($input, $status);
+
+        $this->assertSame(0, $status);
+        $ingest->assertWrittenTimes(0);
+    }
 }
 
 class ParentCommand extends Command


### PR DESCRIPTION
This PR ignores the `php artisan schedule:finish` command, as it can consume a lot of events without providing much value. It's an internal command Laravel uses to do clean-up work after a background command has run.