### PR TITLE
fix: remove errant @internal tag on Core

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -13,8 +13,6 @@ use Throwable;
 use WeakMap;
 
 /**
- * @internal
- *
  * @template TState of RequestState|CommandState
  */
 final class Core


### PR DESCRIPTION
Hello!

The `Core` class should **not** be marked as `@internal` because it has methods that are explicitly marked as `@api`:


```php
Nightwatch::resolved(function (Core $nightwatch): void {
    $nightwatch->rejectCacheEvents($this->rejectCacheEvents(...));
    $nightwatch->rejectQueries($this->rejectQueries(...));
    $nightwatch->rejectQueuedJobs($this->rejectQueuedJobs(...));
});
```

This is resulting in PHPStan failures:
```json
{
    "description": "Call to method rejectCacheEvents() of internal class Laravel\\Nightwatch\\Core from outside its root namespace Laravel.",
    "check_name": "method.internalClass",
    "fingerprint": "f2c7251e5049aaa4b27e732f854bd81598d2c2abc93052c437cbf04b0170f55a",
    "severity": "major",
    "location": {
        "path": "app/Providers/NightwatchServiceProvider.php",
        "lines": {
            "begin": 22
        }
    }
},
```

Thanks!