### PR TITLE
Allow interaction with the Core class

### DIFF
--- a/src/Core.php
+++ b/src/Core.php
@@ -13,8 +13,6 @@ use Throwable;
 use WeakMap;
 
 /**
- * @internal
- *
  * @template TState of RequestState|CommandState
  */
 final class Core
@@ -49,11 +47,17 @@ final class Core
      * }  $config
      */
     public function __construct(
+        /** @internal */
         public Ingest $ingest,
+        /** @internal */
         public SensorManager $sensor,
+        /** @internal */
         public RequestState|CommandState $executionState,
+        /** @internal */
         public Clock $clock,
+        /** @internal */
         public Uuid $uuid,
+        /** @internal */
         public array $config,
     ) {
         $this->routesWithMiddlewareRegistered = new WeakMap;

--- a/tests/Unit/ArchitectureTest.php
+++ b/tests/Unit/ArchitectureTest.php
@@ -3,14 +3,20 @@
 namespace Tests\Unit;
 
 use FilesystemIterator;
+use Laravel\Nightwatch\Core;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use ReflectionClass;
+use ReflectionMethod;
+use ReflectionProperty;
 use Tests\TestCase;
 
+use function count;
 use function explode;
 use function in_array;
+use function str_contains;
 use function str_replace;
+use function trim;
 
 class ArchitectureTest extends TestCase
 {
@@ -26,6 +32,7 @@ class ArchitectureTest extends TestCase
     public function test_classes_are_internal(): void
     {
         $except = [
+            \Laravel\Nightwatch\Core::class,
             \Laravel\Nightwatch\Facades\Nightwatch::class,
             \Laravel\Nightwatch\Http\Middleware\Sample::class,
             \Laravel\Nightwatch\Records\CacheEvent::class,
@@ -42,8 +49,26 @@ class ArchitectureTest extends TestCase
 
         foreach ($this->classes() as $class) {
             if (! in_array($class->getName(), $except, true)) {
-                $this->assertContains(' * @internal', explode("\n", $class->getDocComment()), "[{$class->getName()}] is not marked as internal. Add the @internal docblock tag to it or ignore it");
+                $this->assertTrue($this->markedInteral($class), "[{$class->getName()}] is not marked as internal. Add the @internal docblock tag to it or ignore it");
             }
+        }
+    }
+
+    public function test_core_class_methods_are_correctly_marked_as_api_or_internal(): void
+    {
+        foreach ((new ReflectionClass(Core::class))->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getName() === '__construct') {
+                continue;
+            }
+
+            $this->assertTrue($this->markedInteral($method) || $this->markedApi($method), '['.Core::class."::{$method->getName()}] is not marked as internal or api. Add the @internal docblock to exclude it from the facade or the @api take to include it");
+        }
+    }
+
+    public function test_core_class_properties_are_correctly_marked_as_api_or_internal(): void
+    {
+        foreach ((new ReflectionClass(Core::class))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $this->assertTrue($this->markedInteral($property) || $this->markedApi($property), '['.Core::class."::\${$property->getName()}] is not marked as internal or api. Add the @internal docblock to exclude it from the facade or the @api take to include it");
         }
     }
 
@@ -59,5 +84,39 @@ class ArchitectureTest extends TestCase
                 'Laravel\\Nightwatch\\'.str_replace([$src, '.php', '/'], ['', '', '\\'], $file->getPathname())
             );
         }
+    }
+
+    private function markedInteral(ReflectionClass|ReflectionMethod|ReflectionProperty $item): bool
+    {
+        $lines = explode("\n", $item->getDocComment());
+
+        if (count($lines) === 1) {
+            return $lines[0] === '/** @internal */';
+        }
+
+        foreach ($lines as $line) {
+            if (str_contains(trim($line), '* @internal')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function markedApi(ReflectionClass|ReflectionMethod|ReflectionProperty $item): bool
+    {
+        $lines = explode("\n", $item->getDocComment());
+
+        if (count($lines) === 1) {
+            return $lines[0] === '/** @api */';
+        }
+
+        foreach ($lines as $line) {
+            if (str_contains(trim($line), '* @api')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Removes `@internal` marker from the core class. Adds architecture tests to ensure all core methods and properties have explicit `@api` or `@internal` markers.


These markers indicate our public vs private API and give static analysis / IDE errors if using something internal. They also determine what is included in the facacde docblock.