### PR TITLE
Add sample rate for scheduled tasks

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -14,6 +14,7 @@ return [
         'requests' => env('NIGHTWATCH_REQUEST_SAMPLE_RATE', 1.0),
         'commands' => env('NIGHTWATCH_COMMAND_SAMPLE_RATE', 1.0),
         'exceptions' => env('NIGHTWATCH_EXCEPTION_SAMPLE_RATE', 1.0),
+        'scheduled_tasks' => env('NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE', 1.0),
     ],
 
     'filtering' => [

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -120,7 +120,7 @@ trait CapturesState
     /**
      * @internal
      */
-    public function configureGlobalScheduledTaskSampling(): void
+    public function configureScheduledTaskSampling(): void
     {
         $this->sample($this->config['sampling']['scheduled_tasks']);
     }
@@ -629,7 +629,7 @@ trait CapturesState
         $this->executionState->trace = $trace;
         $this->executionState->setId($trace);
         $this->executionState->timestamp = $this->clock->microtime();
-        $this->configureGlobalScheduledTaskSampling();
+        $this->configureScheduledTaskSampling();
     }
 
     /**

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -118,6 +118,14 @@ trait CapturesState
     }
 
     /**
+     * @internal
+     */
+    public function configureGlobalScheduledTaskSampling(): void
+    {
+        $this->sample($this->config['sampling']['scheduled_tasks']);
+    }
+
+    /**
      * @api
      */
     public function ignore(callable $callback): mixed
@@ -621,7 +629,7 @@ trait CapturesState
         $this->executionState->trace = $trace;
         $this->executionState->setId($trace);
         $this->executionState->timestamp = $this->clock->microtime();
-        $this->sample();
+        $this->configureGlobalScheduledTaskSampling();
     }
 
     /**

--- a/src/Core.php
+++ b/src/Core.php
@@ -36,6 +36,7 @@ final class Core
      *         requests: float,
      *         commands: float,
      *         exceptions: float,
+     *         scheduled_tasks: float,
      *     },
      *     filtering: array{
      *         ignore_cache_events: bool,

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -107,6 +107,7 @@ final class NightwatchServiceProvider extends ServiceProvider
      *        requests?: float,
      *        commands?: float,
      *        exceptions?: float,
+     *        scheduled_tasks?: float,
      *     },
      *     filtering?: array{
      *         ignore_cache_events?: bool,
@@ -268,6 +269,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                     'requests' => $this->nightwatchConfig['sampling']['requests'] ?? 1.0,
                     'commands' => $this->nightwatchConfig['sampling']['commands'] ?? 1.0,
                     'exceptions' => $this->nightwatchConfig['sampling']['exceptions'] ?? 1.0,
+                    'scheduled_tasks' => $this->nightwatchConfig['sampling']['scheduled_tasks'] ?? 1.0,
                 ],
                 'filtering' => [
                     'ignore_cache_events' => (bool) ($this->nightwatchConfig['filtering']['ignore_cache_events'] ?? false),

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -140,6 +140,7 @@ class CliSamplingTest extends TestCase
         $this->core->config['sampling']['scheduled_tasks'] = 0;
         event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
 
+        event(new ScheduledTaskStarting($this->app[Schedule::class]->call('php artisan inspire')));
         $this->assertFalse(Nightwatch::sampling());
     }
 }

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -134,4 +134,12 @@ class CliSamplingTest extends TestCase
 
         $this->assertTrue(Nightwatch::sampling());
     }
+
+    public function test_it_can_use_global_config_to_sample_scheduled_tasks(): void
+    {
+        $this->core->config['sampling']['scheduled_tasks'] = 0;
+        event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
+
+        $this->assertFalse(Nightwatch::sampling());
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This builds off #308 to add a global sample rate for all scheduled tasks that will be correctly carried through to the task when run in a child process.
