### PR TITLE
Ignore low-value vendor commands by default

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -15,6 +15,7 @@ return [
         'commands' => env('NIGHTWATCH_COMMAND_SAMPLE_RATE', 1.0),
         'exceptions' => env('NIGHTWATCH_EXCEPTION_SAMPLE_RATE', 1.0),
         'scheduled_tasks' => env('NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE', 1.0),
+        'vendor_commands' => env('NIGHTWATCH_VENDOR_COMMAND_SAMPLE_RATE', 0.0),
     ],
 
     'filtering' => [

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -120,6 +120,14 @@ trait CapturesState
     /**
      * @internal
      */
+    public function configureVendorCommandSampling(): void
+    {
+        $this->sample($this->config['sampling']['vendor_commands']);
+    }
+
+    /**
+     * @internal
+     */
     public function configureScheduledTaskSampling(): void
     {
         $this->sample($this->config['sampling']['scheduled_tasks']);

--- a/src/Core.php
+++ b/src/Core.php
@@ -37,6 +37,7 @@ final class Core
      *         commands: float,
      *         exceptions: float,
      *         scheduled_tasks: float,
+     *         vendor_commands: float,
      *     },
      *     filtering: array{
      *         ignore_cache_events: bool,

--- a/src/Hooks/CommandStartingListener.php
+++ b/src/Hooks/CommandStartingListener.php
@@ -135,6 +135,10 @@ final class CommandStartingListener
 
     private function prepareForCommand(CommandStarting $event): void
     {
+        if (! $this->kernel instanceof ConsoleKernel) {
+            return;
+        }
+
         $this->nightwatch->prepareForCommand($event->command);
 
         /**

--- a/src/Hooks/CommandStartingListener.php
+++ b/src/Hooks/CommandStartingListener.php
@@ -54,6 +54,7 @@ final class CommandStartingListener
                 'queue:work', 'queue:listen', 'horizon:work', 'vapor:work' => $this->registerJobHooks($event),
                 'schedule:run', 'schedule:work' => $this->registerScheduledTaskHooks(),
                 'schedule:finish' => null,
+                'horizon:snapshot', 'horizon:status', 'passport:purge', 'sanctum:prune-expired', 'model:prune', 'auth:clear-resets' => $this->registerVendorCommandHooks($event),
                 default => $this->registerCommandHooks($event),
             };
         } catch (Throwable $e) {
@@ -118,6 +119,22 @@ final class CommandStartingListener
 
         $this->nightwatch->configureCommandSampling();
 
+        $this->prepareForCommand($event);
+    }
+
+    private function registerVendorCommandHooks(CommandStarting $event): void
+    {
+        if (! $this->kernel instanceof ConsoleKernel) {
+            return;
+        }
+
+        $this->nightwatch->configureVendorCommandSampling();
+
+        $this->prepareForCommand($event);
+    }
+
+    private function prepareForCommand(CommandStarting $event): void
+    {
         $this->nightwatch->prepareForCommand($event->command);
 
         /**

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -108,6 +108,7 @@ final class NightwatchServiceProvider extends ServiceProvider
      *        commands?: float,
      *        exceptions?: float,
      *        scheduled_tasks?: float,
+     *        vendor_commands?: float,
      *     },
      *     filtering?: array{
      *         ignore_cache_events?: bool,
@@ -270,6 +271,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                     'commands' => $this->nightwatchConfig['sampling']['commands'] ?? 1.0,
                     'exceptions' => $this->nightwatchConfig['sampling']['exceptions'] ?? 1.0,
                     'scheduled_tasks' => $this->nightwatchConfig['sampling']['scheduled_tasks'] ?? 1.0,
+                    'vendor_commands' => $this->nightwatchConfig['sampling']['vendor_commands'] ?? 0.0,
                 ],
                 'filtering' => [
                     'ignore_cache_events' => (bool) ($this->nightwatchConfig['filtering']['ignore_cache_events'] ?? false),

--- a/tests/Feature/Sensors/CommandSensorTest.php
+++ b/tests/Feature/Sensors/CommandSensorTest.php
@@ -12,7 +12,9 @@ use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Laravel\Nightwatch\Compatibility;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
 
 use function array_shift;
@@ -284,6 +286,28 @@ class CommandSensorTest extends TestCase
 
         $this->assertSame(0, $status);
         $ingest->assertWrittenTimes(0);
+    }
+
+    #[DataProvider('vendorCommands')]
+    public function test_it_samples_vendor_commands_separately(string $command): void
+    {
+        $ingest = $this->fakeIngest();
+        Artisan::command($command, function () {});
+
+        $status = Artisan::handle($input = new StringInput($command), new NullOutput);
+        Artisan::terminate($input, $status);
+
+        $ingest->assertWrittenTimes(0);
+    }
+
+    public static function vendorCommands(): iterable
+    {
+        yield ['model:prune'];
+        yield ['horizon:snapshot'];
+        yield ['horizon:status'];
+        yield ['passport:purge'];
+        yield ['sanctum:prune-expired'];
+        yield ['auth:clear-resets'];
     }
 }
 


### PR DESCRIPTION
This will ignore the below vendor commands by default but allows the sample them through an environment variable. As these are built-in or vendor commands, 100% sampling is often not necessary.

- model:prune
- horizon:snapshot
- horizon:status
- passport:purge
- sanctum:prune-expired
- auth:clear-resets