### PR TITLE
Disable vendor command sampling by default

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -48,6 +48,7 @@ use function in_array;
 use function memory_reset_peak_usage;
 use function preg_match;
 use function random_int;
+use function str_contains;
 
 /**
  * @internal
@@ -137,11 +138,19 @@ trait CapturesState
      */
     public function configureScheduledTaskSampling(Event $event): void
     {
-        if (! $this->captureDefaultVendorCommands && in_array($event->command, $this->defaultVendorCommands(), true)) {
-            $this->dontSample();
+        $rate = $this->config['sampling']['scheduled_tasks'];
+
+        if (! $this->captureDefaultVendorCommands) {
+            foreach ($this->defaultVendorCommands() as $vendorCommand) {
+                if (str_contains($event->command, $vendorCommand)) {
+                    $rate = 0.0;
+
+                    break;
+                }
+            }
         }
 
-        $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $this->config['sampling']['scheduled_tasks']);
+        $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $rate);
     }
 
     /**

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -150,7 +150,7 @@ trait CapturesState
             $command = preg_split('/\s+/', trim($command), 2)[0] ?? '';
 
             if (in_array($command, $this->defaultVendorCommands(), true)) {
-                $this->sample(0.0);
+                $this->dontSample();
 
                 return;
             }

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -47,8 +47,10 @@ use function env;
 use function in_array;
 use function memory_reset_peak_usage;
 use function preg_match;
+use function preg_split;
 use function random_int;
-use function str_contains;
+use function str_replace;
+use function trim;
 
 /**
  * @internal
@@ -140,14 +142,16 @@ trait CapturesState
     {
         $rate = $this->config['sampling']['scheduled_tasks'];
 
-        if (! $this->captureDefaultVendorCommands) {
-            foreach ($this->defaultVendorCommands() as $command) {
-                if (str_contains($event->command ?? '', $command)) {
-                    $rate = 0.0;
+        $command = str_replace(
+            [Artisan::phpBinary(), Artisan::artisanBinary()],
+            '',
+            $event->command
+        );
 
-                    break;
-                }
-            }
+        $command = preg_split('/\s+/', trim($command), 2)[0] ?? '';
+
+        if (! $this->captureDefaultVendorCommands && in_array($command, $this->defaultVendorCommands(), true)) {
+            $rate = 0.0;
         }
 
         $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $rate);

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -169,12 +169,10 @@ trait CapturesState
     public static function defaultVendorCommands(): array
     {
         return [
-            'auth:clear-resets',
             'horizon:snapshot',
             'horizon:status',
-            'model:prune',
-            'passport:purge',
-            'sanctum:prune-expired',
+            'queue:monitor',
+            'schedule:list',
         ];
     }
 

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -59,6 +59,8 @@ trait CapturesState
 
     private bool $paused = false;
 
+    private bool $captureDefaultVendorCommands = false;
+
     /**
      * @var WeakMap<Event, float>
      */
@@ -129,6 +131,31 @@ trait CapturesState
     public function configureScheduledTaskSampling(Event $event): void
     {
         $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $this->config['sampling']['scheduled_tasks']);
+    }
+
+    /**
+     * @api
+     */
+    public function captureDefaultVendorCommands(bool $capture = true): void
+    {
+        $this->captureDefaultVendorCommands = $capture;
+    }
+
+    /**
+     * @api
+     *
+     * @return list<string>
+     */
+    public static function defaultVendorCommands(): array
+    {
+        return [
+            'auth:clear-resets',
+            'horizon:snapshot',
+            'horizon:status',
+            'model:prune',
+            'passport:purge',
+            'sanctum:prune-expired',
+        ];
     }
 
     /**

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -140,18 +140,20 @@ trait CapturesState
      */
     public function configureScheduledTaskSampling(Event $event): void
     {
-        $command = str_replace(
-            [Artisan::phpBinary(), Artisan::artisanBinary()],
-            '',
-            $event->command ?? ''
-        );
+        if (! $this->captureDefaultVendorCommands) {
+            $command = str_replace(
+                [Artisan::phpBinary(), Artisan::artisanBinary()],
+                '',
+                $event->command ?? ''
+            );
 
-        $command = preg_split('/\s+/', trim($command), 2)[0] ?? '';
+            $command = preg_split('/\s+/', trim($command), 2)[0] ?? '';
 
-        if (! $this->captureDefaultVendorCommands && in_array($command, $this->defaultVendorCommands(), true)) {
-            $this->sample(0.0);
+            if (in_array($command, $this->defaultVendorCommands(), true)) {
+                $this->sample(0.0);
 
-            return;
+                return;
+            }
         }
 
         $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $this->config['sampling']['scheduled_tasks']);

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -141,8 +141,8 @@ trait CapturesState
         $rate = $this->config['sampling']['scheduled_tasks'];
 
         if (! $this->captureDefaultVendorCommands) {
-            foreach ($this->defaultVendorCommands() as $vendorCommand) {
-                if (str_contains($event->command, $vendorCommand)) {
+            foreach ($this->defaultVendorCommands() as $command) {
+                if (str_contains($event->command ?? '', $command)) {
                     $rate = 0.0;
 
                     break;

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -145,7 +145,7 @@ trait CapturesState
         $command = str_replace(
             [Artisan::phpBinary(), Artisan::artisanBinary()],
             '',
-            $event->command
+            $event->command ?? ''
         );
 
         $command = preg_split('/\s+/', trim($command), 2)[0] ?? '';

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -140,8 +140,6 @@ trait CapturesState
      */
     public function configureScheduledTaskSampling(Event $event): void
     {
-        $rate = $this->config['sampling']['scheduled_tasks'];
-
         $command = str_replace(
             [Artisan::phpBinary(), Artisan::artisanBinary()],
             '',
@@ -151,10 +149,12 @@ trait CapturesState
         $command = preg_split('/\s+/', trim($command), 2)[0] ?? '';
 
         if (! $this->captureDefaultVendorCommands && in_array($command, $this->defaultVendorCommands(), true)) {
-            $rate = 0.0;
+            $this->sample(0.0);
+
+            return;
         }
 
-        $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $rate);
+        $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $this->config['sampling']['scheduled_tasks']);
     }
 
     /**

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -44,6 +44,7 @@ use function array_shift;
 use function array_unshift;
 use function debug_backtrace;
 use function env;
+use function in_array;
 use function memory_reset_peak_usage;
 use function preg_match;
 use function random_int;
@@ -116,8 +117,12 @@ trait CapturesState
     /**
      * @internal
      */
-    public function configureCommandSampling(): void
+    public function configureCommandSampling(string $command): void
     {
+        if (in_array($command, $this->defaultVendorCommands(), true)) {
+            $this->dontSample();
+        }
+
         $this->sample(match (Compatibility::getSamplingFromContext(null)) {
             true => 1.0,
             false => 0.0,

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -119,8 +119,10 @@ trait CapturesState
      */
     public function configureCommandSampling(string $command): void
     {
-        if (in_array($command, $this->defaultVendorCommands(), true)) {
+        if (! $this->captureDefaultVendorCommands && in_array($command, $this->defaultVendorCommands(), true)) {
             $this->dontSample();
+
+            return;
         }
 
         $this->sample(match (Compatibility::getSamplingFromContext(null)) {
@@ -135,6 +137,10 @@ trait CapturesState
      */
     public function configureScheduledTaskSampling(Event $event): void
     {
+        if (! $this->captureDefaultVendorCommands && in_array($event->command, $this->defaultVendorCommands(), true)) {
+            $this->dontSample();
+        }
+
         $this->sample(rate: $this->scheduledTasksSampleRates[$event] ?? $this->config['sampling']['scheduled_tasks']);
     }
 

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -169,9 +169,18 @@ trait CapturesState
     public static function defaultVendorCommands(): array
     {
         return [
+            'auth:clear-resets',
+            'config:cache',
             'horizon:snapshot',
             'horizon:status',
+            'horizon:supervisor',
+            'inertia:start-ssr',
+            'invoke-serialized-closure',
+            'model:prune',
+            'nightwatch:agent',
+            'nightwatch:status',
             'queue:monitor',
+            'reverb:start',
             'schedule:list',
         ];
     }

--- a/src/Facades/Nightwatch.php
+++ b/src/Facades/Nightwatch.php
@@ -29,6 +29,8 @@ use function call_user_func;
  * @method static void rejectCacheKeys(array $keys)
  * @method static void captureDefaultVendorCacheKeys(bool $capture = true)
  * @method static array defaultVendorCacheKeys()
+ * @method static void captureDefaultVendorCommands(bool $capture = true)
+ * @method static array defaultVendorCommands()
  * @method static void rejectMail(callable $callback)
  * @method static void rejectNotifications(callable $callback)
  * @method static void rejectOutgoingRequests(callable $callback)

--- a/src/Hooks/CommandStartingListener.php
+++ b/src/Hooks/CommandStartingListener.php
@@ -53,7 +53,7 @@ final class CommandStartingListener
             match ($event->command) {
                 'queue:work', 'queue:listen', 'horizon:work', 'vapor:work' => $this->registerJobHooks($event),
                 'schedule:run', 'schedule:work' => $this->registerScheduledTaskHooks(),
-                'schedule:finish' => null,
+                'help', 'inspire', 'schedule:finish' => null,
                 default => $this->registerCommandHooks($event),
             };
         } catch (Throwable $e) {

--- a/src/Hooks/CommandStartingListener.php
+++ b/src/Hooks/CommandStartingListener.php
@@ -116,7 +116,7 @@ final class CommandStartingListener
             return;
         }
 
-        $this->nightwatch->configureCommandSampling();
+        $this->nightwatch->configureCommandSampling($event->command);
 
         $this->nightwatch->prepareForCommand($event->command);
 

--- a/src/Hooks/ScheduledTaskStartingListener.php
+++ b/src/Hooks/ScheduledTaskStartingListener.php
@@ -7,6 +7,8 @@ use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
 use Throwable;
 
+use function in_array;
+
 /**
  * @internal
  */
@@ -24,7 +26,11 @@ final class ScheduledTaskStartingListener
     public function __invoke(ScheduledTaskStarting $event): void
     {
         try {
-            $this->nightwatch->prepareForNextScheduledTask($event->task);
+            $this->nightwatch->prepareForNextScheduledTask();
+
+            if (in_array($event->task->command, $this->nightwatch->defaultVendorCommands(), true)) {
+                $this->nightwatch->dontSample();
+            }
         } catch (Throwable $e) {
             $this->nightwatch->report($e, handled: true);
         }

--- a/src/Hooks/ScheduledTaskStartingListener.php
+++ b/src/Hooks/ScheduledTaskStartingListener.php
@@ -7,8 +7,6 @@ use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\State\CommandState;
 use Throwable;
 
-use function in_array;
-
 /**
  * @internal
  */
@@ -26,11 +24,7 @@ final class ScheduledTaskStartingListener
     public function __invoke(ScheduledTaskStarting $event): void
     {
         try {
-            $this->nightwatch->prepareForNextScheduledTask();
-
-            if (in_array($event->task->command, $this->nightwatch->defaultVendorCommands(), true)) {
-                $this->nightwatch->dontSample();
-            }
+            $this->nightwatch->prepareForNextScheduledTask($event->task);
         } catch (Throwable $e) {
             $this->nightwatch->report($e, handled: true);
         }

--- a/tests/Feature/Sensors/CommandSensorTest.php
+++ b/tests/Feature/Sensors/CommandSensorTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Laravel\Nightwatch\Compatibility;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
@@ -276,37 +277,23 @@ class CommandSensorTest extends TestCase
         $ingest->assertLatestWrite('cache-event:0.execution_stage', 'action');
     }
 
-    public function test_it_ignores_schedule_finish_command(): void
+    #[DataProvider('vendorCommands')]
+    public function test_it_ignores_vendor_commands(string $command): void
     {
         $ingest = $this->fakeIngest();
 
-        $status = Artisan::handle($input = new StringInput('schedule:finish 123'));
+        $status = Artisan::handle($input = new StringInput($command), new NullOutput);
         Artisan::terminate($input, $status);
 
         $this->assertSame(0, $status);
         $ingest->assertWrittenTimes(0);
     }
 
-    public function test_it_ignores_inspire_command(): void
+    public static function vendorCommands(): iterable
     {
-        $ingest = $this->fakeIngest();
-
-        $status = Artisan::handle($input = new StringInput('inspire'), new NullOutput);
-        Artisan::terminate($input, $status);
-
-        $this->assertSame(0, $status);
-        $ingest->assertWrittenTimes(0);
-    }
-
-    public function test_it_ignores_help_command(): void
-    {
-        $ingest = $this->fakeIngest();
-
-        $status = Artisan::handle($input = new StringInput('help'), new NullOutput);
-        Artisan::terminate($input, $status);
-
-        $this->assertSame(0, $status);
-        $ingest->assertWrittenTimes(0);
+        yield ['help'];
+        yield ['inspire'];
+        yield ['schedule:finish 123'];
     }
 }
 

--- a/tests/Feature/Sensors/CommandSensorTest.php
+++ b/tests/Feature/Sensors/CommandSensorTest.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Laravel\Nightwatch\Compatibility;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
 
 use function array_shift;
@@ -280,6 +281,28 @@ class CommandSensorTest extends TestCase
         $ingest = $this->fakeIngest();
 
         $status = Artisan::handle($input = new StringInput('schedule:finish 123'));
+        Artisan::terminate($input, $status);
+
+        $this->assertSame(0, $status);
+        $ingest->assertWrittenTimes(0);
+    }
+
+    public function test_it_ignores_inspire_command(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $status = Artisan::handle($input = new StringInput('inspire'), new NullOutput);
+        Artisan::terminate($input, $status);
+
+        $this->assertSame(0, $status);
+        $ingest->assertWrittenTimes(0);
+    }
+
+    public function test_it_ignores_help_command(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $status = Artisan::handle($input = new StringInput('help'), new NullOutput);
         Artisan::terminate($input, $status);
 
         $this->assertSame(0, $status);

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -222,11 +222,9 @@ class CliSamplingTest extends TestCase
 
     public static function vendorCommands(): iterable
     {
-        yield ['model:prune'];
         yield ['horizon:snapshot'];
         yield ['horizon:status'];
-        yield ['passport:purge'];
-        yield ['sanctum:prune-expired'];
-        yield ['auth:clear-resets'];
+        yield ['queue:monitor'];
+        yield ['schedule:list'];
     }
 }

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
 
+use function dirname;
 use function event;
 
 class CliSamplingTest extends TestCase
@@ -28,6 +29,8 @@ class CliSamplingTest extends TestCase
         $this->forceCommandExecutionState();
 
         parent::setUp();
+
+        $this->app->setBasePath(dirname($this->app->basePath()));
     }
 
     public function test_it_samples_job_attempts(): void
@@ -132,7 +135,7 @@ class CliSamplingTest extends TestCase
         event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
 
         Nightwatch::dontSample();
-        event(new ScheduledTaskStarting($this->app[Schedule::class]->call('php artisan inspire')));
+        event(new ScheduledTaskStarting($this->app[Schedule::class]->command('inspire')));
 
         $this->assertTrue(Nightwatch::sampling());
     }
@@ -181,7 +184,6 @@ class CliSamplingTest extends TestCase
     public function test_it_samples_vendor_commands_separately(string $command): void
     {
         $ingest = $this->fakeIngest();
-        Artisan::command($command, function () {});
 
         $status = Artisan::handle($input = new StringInput($command), new NullOutput);
         Artisan::terminate($input, $status);
@@ -192,34 +194,25 @@ class CliSamplingTest extends TestCase
     #[DataProvider('vendorCommands')]
     public function test_it_samples_vendor_scheduled_tasks_separately(string $command): void
     {
-        $ingest = $this->fakeIngest();
-        Artisan::command($command, function () {});
+        event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
 
-        $this->app[Schedule::class]->command($command)->everyMinute();
+        event(new ScheduledTaskStarting($this->app[Schedule::class]->command($command)->everyMinute()));
 
-        Artisan::call('schedule:run');
-
-        $this->assertCount(0, $ingest->writes());
-        $this->assertCount(0, $this->core->ingest->buffer);
+        $this->assertFalse(Nightwatch::sampling());
     }
 
     #[DataProvider('vendorCommands')]
     public function test_it_samples_vendor_scheduled_tasks_when_explicitly_sampled(string $command): void
     {
-        $ingest = $this->fakeIngest();
-        Artisan::command($command, function () {});
+        event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
 
-        $this->app[Schedule::class]->command($command)->everyMinute()->tap(Sample::rate(0.5));
-
-        $writes = 0;
+        $samples = 0;
         for ($i = 0; $i < 100; $i++) {
-            Artisan::call('schedule:run');
-            $writes += $ingest->writes()->count();
-            $ingest->forgetWrites();
+            event(new ScheduledTaskStarting($this->app[Schedule::class]->command($command)->everyMinute()->tap(Sample::rate(0.5))));
+            $samples += (int) Nightwatch::sampling();
         }
 
-        $this->assertEqualsWithDelta(50, $writes, 20);
-        $this->assertCount(0, $this->core->ingest->buffer);
+        $this->assertEqualsWithDelta(50, $samples, 20);
     }
 
     public static function vendorCommands(): iterable

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -193,6 +193,7 @@ class CliSamplingTest extends TestCase
     public function test_it_samples_vendor_scheduled_tasks_separately(string $command): void
     {
         $ingest = $this->fakeIngest();
+        Artisan::command($command, function () {});
 
         $this->app[Schedule::class]->command($command)->everyMinute();
 
@@ -206,6 +207,7 @@ class CliSamplingTest extends TestCase
     public function test_it_samples_vendor_scheduled_tasks_when_explicitly_sampled(string $command): void
     {
         $ingest = $this->fakeIngest();
+        Artisan::command($command, function () {});
 
         $this->app[Schedule::class]->command($command)->everyMinute()->tap(Sample::rate(0.5));
 

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -219,7 +219,7 @@ class CliSamplingTest extends TestCase
     {
         yield ['horizon:snapshot'];
         yield ['horizon:status'];
-        yield ['queue:monitor'];
+        yield ['queue:monitor default'];
         yield ['schedule:list'];
     }
 }

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -187,7 +187,7 @@ class CliSamplingTest extends TestCase
     }
 
     #[DataProvider('vendorCommands')]
-    public function test_it_samples_vendor_commands_separately(string $command): void
+    public function test_it_does_not_sample_vendor_commands(string $command): void
     {
         $ingest = $this->fakeIngest();
         Artisan::command($command, fn () => 0);
@@ -213,7 +213,7 @@ class CliSamplingTest extends TestCase
     }
 
     #[DataProvider('vendorCommands')]
-    public function test_it_samples_vendor_scheduled_tasks_separately(string $command): void
+    public function test_it_does_not_sample_scheduled_vendor_commands(string $command): void
     {
         event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
 

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -237,6 +237,7 @@ class CliSamplingTest extends TestCase
     #[DataProvider('vendorCommands')]
     public function test_it_samples_vendor_scheduled_tasks_when_explicitly_sampled(string $command): void
     {
+        Nightwatch::captureDefaultVendorCommands();
         event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
 
         $samples = 0;

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Artisan;
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Console\Sample;
 use Laravel\Nightwatch\Facades\Nightwatch;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
@@ -151,7 +152,7 @@ class CliSamplingTest extends TestCase
             $ingest->forgetWrites();
         }
 
-        $this->assertEqualsWithDelta(50, $writes, 10);
+        $this->assertEqualsWithDelta(50, $writes, 20);
         $this->assertCount(0, $this->core->ingest->buffer);
     }
 
@@ -174,5 +175,58 @@ class CliSamplingTest extends TestCase
 
         $this->assertSame(100, $writes);
         $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    #[DataProvider('vendorCommands')]
+    public function test_it_samples_vendor_commands_separately(string $command): void
+    {
+        $ingest = $this->fakeIngest();
+        Artisan::command($command, function () {});
+
+        $status = Artisan::handle($input = new StringInput($command), new NullOutput);
+        Artisan::terminate($input, $status);
+
+        $ingest->assertWrittenTimes(0);
+    }
+
+    #[DataProvider('vendorCommands')]
+    public function test_it_samples_vendor_scheduled_tasks_separately(string $command): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $this->app[Schedule::class]->command($command)->everyMinute();
+
+        Artisan::call('schedule:run');
+
+        $this->assertCount(0, $ingest->writes());
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    #[DataProvider('vendorCommands')]
+    public function test_it_samples_vendor_scheduled_tasks_when_explicitly_sampled(string $command): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $this->app[Schedule::class]->command($command)->everyMinute()->tap(Sample::rate(0.5));
+
+        $writes = 0;
+        for ($i = 0; $i < 100; $i++) {
+            Artisan::call('schedule:run');
+            $writes += $ingest->writes()->count();
+            $ingest->forgetWrites();
+        }
+
+        $this->assertEqualsWithDelta(50, $writes, 20);
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    public static function vendorCommands(): iterable
+    {
+        yield ['model:prune'];
+        yield ['horizon:snapshot'];
+        yield ['horizon:status'];
+        yield ['passport:purge'];
+        yield ['sanctum:prune-expired'];
+        yield ['auth:clear-resets'];
     }
 }

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -19,6 +19,7 @@ use Tests\TestCase;
 
 use function dirname;
 use function event;
+use function fake;
 
 class CliSamplingTest extends TestCase
 {
@@ -133,9 +134,14 @@ class CliSamplingTest extends TestCase
     public function test_it_resets_sampling_after_each_task(): void
     {
         event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
+        Artisan::command($command = fake()->name(), fn () => 0);
 
         Nightwatch::dontSample();
-        event(new ScheduledTaskStarting($this->app[Schedule::class]->command('inspire')));
+        event(new ScheduledTaskStarting($this->app[Schedule::class]->command($command)));
+        $this->assertTrue(Nightwatch::sampling());
+
+        Artisan::command($command = fake()->name(), fn () => 0);
+        event(new ScheduledTaskStarting($this->app[Schedule::class]->command($command)));
 
         $this->assertTrue(Nightwatch::sampling());
     }
@@ -184,6 +190,7 @@ class CliSamplingTest extends TestCase
     public function test_it_samples_vendor_commands_separately(string $command): void
     {
         $ingest = $this->fakeIngest();
+        Artisan::command($command, fn () => 0);
 
         $status = Artisan::handle($input = new StringInput($command), new NullOutput);
         Artisan::terminate($input, $status);
@@ -217,9 +224,18 @@ class CliSamplingTest extends TestCase
 
     public static function vendorCommands(): iterable
     {
+        yield ['auth:clear-resets'];
+        yield ['config:cache'];
         yield ['horizon:snapshot'];
         yield ['horizon:status'];
-        yield ['queue:monitor default'];
+        yield ['horizon:supervisor'];
+        yield ['inertia:start-ssr'];
+        yield ['invoke-serialized-closure'];
+        yield ['model:prune'];
+        yield ['nightwatch:agent'];
+        yield ['nightwatch:status'];
+        yield ['queue:monitor'];
+        yield ['reverb:start'];
         yield ['schedule:list'];
     }
 }

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -199,6 +199,20 @@ class CliSamplingTest extends TestCase
     }
 
     #[DataProvider('vendorCommands')]
+    public function test_it_samples_vendor_commands_when_enabled(string $command): void
+    {
+        $ingest = $this->fakeIngest();
+        Artisan::command($command, fn () => 0);
+
+        Nightwatch::captureDefaultVendorCommands();
+
+        $status = Artisan::handle($input = new StringInput($command), new NullOutput);
+        Artisan::terminate($input, $status);
+
+        $ingest->assertWrittenTimes(1);
+    }
+
+    #[DataProvider('vendorCommands')]
     public function test_it_samples_vendor_scheduled_tasks_separately(string $command): void
     {
         event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
@@ -206,6 +220,18 @@ class CliSamplingTest extends TestCase
         event(new ScheduledTaskStarting($this->app[Schedule::class]->command($command)->everyMinute()));
 
         $this->assertFalse(Nightwatch::sampling());
+    }
+
+    #[DataProvider('vendorCommands')]
+    public function test_it_samples_vendor_scheduled_tasks_when_enabled(string $command): void
+    {
+        Nightwatch::captureDefaultVendorCommands();
+
+        event(new CommandStarting('schedule:run', new StringInput(''), new NullOutput));
+
+        event(new ScheduledTaskStarting($this->app[Schedule::class]->command($command)->everyMinute()));
+
+        $this->assertTrue(Nightwatch::sampling());
     }
 
     #[DataProvider('vendorCommands')]


### PR DESCRIPTION
Ignore traces of vendor commands by default and allow users to enable them with `Nightwatch::captureDefaultVendorCommands()`.

This will ignore them when ran manually or when run as a scheduled task

The commands to include here were chosen based on their relative usefulness, the number of times the commands have shown up in production, how many events each command is likely to contain and the context in which they are run (manually, or scheduled, or health check, etc).

Some commands start other non-PHP processes and so have very small utility in tracing. All are built-in or first party Laravel packages.

It's important to note that this will ignore them by default but this can be changed by calling `Nightwatch::captureDefaultVendorCommands()` or by manually sampling in the command or scheduled task at runtime.