### PR TITLE
Update changelog with scheduled task mention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 
 **Full Changelog**: https://github.com/laravel/nightwatch/compare/v1.19.0...v1.20.0
 
-## Changes to scheduled task sampling
+### Changes to scheduled task sampling
 
 With this release, scheduled tasks are able to be sampled separately from commands. If you were relying on `NIGHTWATCH_COMMAND_SAMPLE_RATE` to also change sampling of scheduled tasks, you will need to update `NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE` accordingly as this takes precedence.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
 **Full Changelog**: https://github.com/laravel/nightwatch/compare/v1.19.0...v1.20.0
 
+## Changes to scheduled task sampling
+
+With this release, scheduled tasks are able to be sampled separately from commands. If you were relying on `NIGHTWATCH_COMMAND_SAMPLE_RATE` to also change sampling of scheduled tasks, you will need to update `NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE` accordingly as this takes precedence.
+
 ## [v1.19.0](https://github.com/laravel/nightwatch/compare/v1.18.1...v1.19.0) - 2025-11-25
 
 ### What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 
 ### Changes to scheduled task sampling
 
-With this release, scheduled tasks are able to be sampled separately from commands. If you were relying on `NIGHTWATCH_COMMAND_SAMPLE_RATE` to also change sampling of scheduled tasks, you will need to update `NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE` accordingly as this takes precedence.
+With this release, scheduled tasks are able to be sampled separately from commands. If you were relying on `NIGHTWATCH_COMMAND_SAMPLE_RATE` to also change sampling of scheduled commands, you will need to update `NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE` accordingly as this takes precedence.
 
 ## [v1.19.0](https://github.com/laravel/nightwatch/compare/v1.18.1...v1.19.0) - 2025-11-25
 


### PR DESCRIPTION
Update the changelog to match the release notes for 1.20.0 regarding the precedence of environment variables with scheduled task commands.
