### PR TITLE
Capture query connection type (read or write)

### DIFF
--- a/src/Compatibility.php
+++ b/src/Compatibility.php
@@ -39,6 +39,8 @@ final class Compatibility
 
     public static bool $subMinuteScheduledTasksSupported = false;
 
+    public static bool $queryConnectionTypeCapturable = false;
+
     /**
      * @var array{
      *   nightwatch_should_sample?: bool|null,
@@ -113,6 +115,12 @@ final class Compatibility
         if (version_compare($version, '11.5.0', '<')) {
             Event::macro('tap', fn (callable $callable) => tap($this, $callable));
         }
+
+        /**
+         * @see https://github.com/laravel/framework/pull/58156
+         * @see https://github.com/laravel/framework/releases/tag/v12.45.0
+         */
+        self::$queryConnectionTypeCapturable = version_compare($version, '12.45.0', '>=');
     }
 
     /**

--- a/src/QueryConnectionType.php
+++ b/src/QueryConnectionType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Laravel\Nightwatch;
+
+enum QueryConnectionType: string
+{
+    case Read = 'read';
+    case Write = 'write';
+    case Unknown = 'unknown';
+}

--- a/src/Records/Query.php
+++ b/src/Records/Query.php
@@ -4,12 +4,16 @@ namespace Laravel\Nightwatch\Records;
 
 final class Query
 {
+    /**
+     * @param  null|'read'|'write'  $connectionType
+     */
     public function __construct(
         public string $sql,
         public readonly string $file,
         public readonly int $line,
         public readonly int $duration,
         public readonly string $connection,
+        public readonly ?string $connectionType,
     ) {
         //
     }

--- a/src/Records/Query.php
+++ b/src/Records/Query.php
@@ -2,18 +2,17 @@
 
 namespace Laravel\Nightwatch\Records;
 
+use Laravel\Nightwatch\QueryConnectionType;
+
 final class Query
 {
-    /**
-     * @param  null|'read'|'write'  $connectionType
-     */
     public function __construct(
         public string $sql,
         public readonly string $file,
         public readonly int $line,
         public readonly int $duration,
         public readonly string $connection,
-        public readonly ?string $connectionType,
+        public readonly QueryConnectionType $connectionType,
     ) {
         //
     }

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -41,8 +41,8 @@ final class QuerySensor
 
         [$file, $line] = $this->location->forQueryTrace($trace);
 
-        $connectionType = Compatibility::$queryConnectionTypeCapturable
-            ? QueryConnectionType::tryFrom($event->readWriteType) ?? QueryConnectionType::Unknown
+        $connectionType = Compatibility::$queryConnectionTypeCapturable && $event->readWriteType !== null
+            ? QueryConnectionType::from($event->readWriteType)
             : QueryConnectionType::Unknown;
 
         return [

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -4,6 +4,7 @@ namespace Laravel\Nightwatch\Sensors;
 
 use Illuminate\Database\Events\QueryExecuted;
 use Laravel\Nightwatch\Clock;
+use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Location;
 use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\State\CommandState;
@@ -46,6 +47,7 @@ final class QuerySensor
                 line: $line ?? 0,
                 duration: $durationInMicroseconds,
                 connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
+                connectionType: Compatibility::$queryConnectionTypeCapturable ? $event->readWriteType : null,
             ),
             function () use ($event, $record) {
                 $this->executionState->queries++;
@@ -68,6 +70,7 @@ final class QuerySensor
                     'line' => $record->line,
                     'duration' => $record->duration,
                     'connection' => Str::tinyText($record->connection),
+                    'connection_type' => $record->connectionType ?? '',
                 ];
             },
         ];

--- a/src/Sensors/QuerySensor.php
+++ b/src/Sensors/QuerySensor.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Events\QueryExecuted;
 use Laravel\Nightwatch\Clock;
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Location;
+use Laravel\Nightwatch\QueryConnectionType;
 use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
@@ -40,6 +41,10 @@ final class QuerySensor
 
         [$file, $line] = $this->location->forQueryTrace($trace);
 
+        $connectionType = Compatibility::$queryConnectionTypeCapturable
+            ? QueryConnectionType::tryFrom($event->readWriteType) ?? QueryConnectionType::Unknown
+            : QueryConnectionType::Unknown;
+
         return [
             $record = new Query(
                 sql: $event->sql,
@@ -47,7 +52,7 @@ final class QuerySensor
                 line: $line ?? 0,
                 duration: $durationInMicroseconds,
                 connection: $event->connectionName ?? '', // @phpstan-ignore nullCoalesce.property
-                connectionType: Compatibility::$queryConnectionTypeCapturable ? $event->readWriteType : null,
+                connectionType: $connectionType,
             ),
             function () use ($event, $record) {
                 $this->executionState->queries++;
@@ -70,7 +75,7 @@ final class QuerySensor
                     'line' => $record->line,
                     'duration' => $record->duration,
                     'connection' => Str::tinyText($record->connection),
-                    'connection_type' => $record->connectionType ?? '',
+                    'connection_type' => $record->connectionType === QueryConnectionType::Unknown ? '' : $record->connectionType->value,
                 ];
             },
         ];

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Laravel\Nightwatch\Compatibility;
 use MongoDB\Laravel\Connection as MongoDbConnection;
 use PDO;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -93,6 +94,7 @@ class QuerySensorTest extends TestCase
                 'line' => $line,
                 'duration' => 4321,
                 'connection' => $connection,
+                'connection_type' => Compatibility::$queryConnectionTypeCapturable ? 'write' : '',
             ],
         ]);
     }

--- a/tests/Feature/Sensors/QuerySensorTest.php
+++ b/tests/Feature/Sensors/QuerySensorTest.php
@@ -22,9 +22,11 @@ use SingleStore\Laravel\Connect\Connection as LegacySingleStoreConnection;
 use SingleStore\Laravel\Connect\SingleStoreConnection;
 use Tests\TestCase;
 
+use function array_merge;
 use function base64_encode;
 use function class_exists;
 use function dirname;
+use function fake;
 use function hash;
 use function hex2bin;
 use function in_array;
@@ -353,5 +355,183 @@ class QuerySensorTest extends TestCase
 
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('query:0.connection', '');
+    }
+
+    public function test_it_captures_connection_type_as_write_when_read_and_write_connections_are_not_configured()
+    {
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : '');
+    }
+
+    public function test_it_captures_connection_type_as_read_for_select_query()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'read' : '');
+    }
+
+    public function test_it_captures_connection_type_as_write_for_write_query()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::table('users')->insert([
+                'name' => fake()->name(),
+                'email' => fake()->email(),
+                'password' => fake()->password(),
+            ]);
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : '');
+    }
+
+    public function test_it_captures_connection_type_as_write_when_records_have_been_modified_and_sticky_connection_is_enabled()
+    {
+        $this->configureReadWriteConnection(['sticky' => true]);
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::table('users')->insert([
+                'name' => fake()->name(),
+                'email' => fake()->email(),
+                'password' => fake()->password(),
+            ]);
+
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : ''); // insert
+        $ingest->assertLatestWrite('query:1.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : ''); // select
+    }
+
+    public function test_it_captures_connection_type_as_write_for_insert_and_read_for_select_when_sticky_connection_is_disabled()
+    {
+        $this->configureReadWriteConnection(['sticky' => false]);
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::table('users')->insert([
+                'name' => fake()->name(),
+                'email' => fake()->email(),
+                'password' => fake()->password(),
+            ]);
+
+            return DB::table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : ''); // insert
+        $ingest->assertLatestWrite('query:1.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'read' : ''); // select
+    }
+
+    public function test_it_captures_connection_type_as_write_when_it_should_use_write_connection_when_reading()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            return DB::useWriteConnectionWhenReading()->table('users')->get();
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : '');
+    }
+
+    public function test_it_captures_connection_type_as_write_when_in_a_transaction()
+    {
+        $this->configureReadWriteConnection();
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::beginTransaction();
+
+            $users = DB::table('users')->get();
+
+            DB::rollBack();
+
+            return $users;
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : '');
+    }
+
+    public function test_it_captures_connection_type_when_forgetting_modified_records_state()
+    {
+        $this->configureReadWriteConnection(['sticky' => true]);
+
+        $ingest = $this->fakeIngest();
+
+        Route::get('/users', function () {
+            DB::statement('select 1');
+            DB::forgetRecordModificationState();
+            DB::select('select 1');
+        });
+
+        $response = $this->get('/users');
+
+        $response->assertOk();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('query:0.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'write' : '');
+        $ingest->assertLatestWrite('query:1.connection_type', Compatibility::$queryConnectionTypeCapturable ? 'read' : '');
+    }
+
+    private function configureReadWriteConnection(array $options = []): void
+    {
+        $connection = Config::get('database.default');
+        $config = Config::get("database.connections.{$connection}");
+
+        Config::set("database.connections.{$connection}", array_merge($config, [
+            'read' => [
+                'database' => $config['database'],
+            ],
+            'write' => [
+                'database' => $config['database'],
+            ],
+        ], $options));
+
+        DB::purge($connection);
     }
 }

--- a/tests/Unit/ArchitectureTest.php
+++ b/tests/Unit/ArchitectureTest.php
@@ -36,6 +36,7 @@ class ArchitectureTest extends TestCase
             \Laravel\Nightwatch\Core::class,
             \Laravel\Nightwatch\Facades\Nightwatch::class,
             \Laravel\Nightwatch\Http\Middleware\Sample::class,
+            \Laravel\Nightwatch\QueryConnectionType::class,
             \Laravel\Nightwatch\Records\CacheEvent::class,
             \Laravel\Nightwatch\Records\Command::class,
             \Laravel\Nightwatch\Records\Exception::class,


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR updates `QuerySensor` to capture the query connection type (read or write).
It's available on Laravel v12.45.0 or later. https://github.com/laravel/framework/pull/58156