### PR TITLE
Make `FakeTcpStream` compatible with Monolog 3.10.0

### DIFF
--- a/tests/FakeTcpStream.php
+++ b/tests/FakeTcpStream.php
@@ -18,11 +18,6 @@ class FakeTcpStream
 
     public string $value = '';
 
-    public function __construct()
-    {
-        self::instances()->push($this);
-    }
-
     public static function instances(): Collection
     {
         return self::$instances ??= new Collection;
@@ -34,7 +29,11 @@ class FakeTcpStream
     public function __call(string $name, array $arguments): mixed
     {
         $handler = match ($name) {
-            'stream_open' => fn (string $path, string $mode, int $options, ?string &$openedPath): bool => true,
+            'stream_open' => function (string $path, string $mode, int $options, ?string &$openedPath): bool {
+                self::instances()->push($this);
+
+                return true;
+            },
             'stream_set_option' => fn (int $option, int $arg1, int $arg2): bool => true,
             'stream_write' => function (string $value): int {
                 $this->value .= $value;
@@ -48,6 +47,7 @@ class FakeTcpStream
                 //
             },
             'stream_seek' => fn () => 0,
+            'url_stat' => fn (string $path, int $flags): array|false => false,
             default => throw new RuntimeException("FakeTcpStream method not implemented [{$name}]"),
         };
 

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -22,7 +22,6 @@ use Tests\TestCase;
 use Throwable;
 
 use function array_map;
-use function base64_encode;
 use function base_path;
 use function collect;
 use function dirname;
@@ -816,14 +815,12 @@ class ExceptionSensorTest extends TestCase
 
         $response->assertServerError();
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.message', function ($message) {
-            $this->assertSame(
-                base64_encode($message),
-                base64_encode('SQLSTATE[HY000]: General error: 1 no such table: unknown-table (Connection: sqlite, SQL: select * from "unknown-table" where "foo" = ��#)')
-            );
 
-            return true;
-        });
+        // @see https://github.com/laravel/framework/pull/58218
+        // @see https://github.com/laravel/framework/releases/tag/v12.45.0
+        $ingest->assertLatestWrite('exception:0.message', version_compare($this->app->version(), '12.45.0', '>=')
+            ? 'SQLSTATE[HY000]: General error: 1 no such table: unknown-table (Connection: sqlite, Database: tests/database.sqlite, SQL: select * from "unknown-table" where "foo" = ��#)'
+            : 'SQLSTATE[HY000]: General error: 1 no such table: unknown-table (Connection: sqlite, SQL: select * from "unknown-table" where "foo" = ��#)');
     }
 
     public function test_it_reports_internally_reported_exceptions_as_handled()


### PR DESCRIPTION
## Problem

Tests started failing after updating to Monolog 3.10.0:

```
RuntimeException: FakeTcpStream method not implemented [url_stat]
```

```
Failed asserting that actual size 3 matches expected size 2.
```


### Cause

Monolog [3.10.0](https://github.com/Seldaek/monolog/releases/tag/3.10.0) (released January 2, 2026) introduced a new feature to detect log file rotation by checking if the file's inode has changed ([Seldaek/monolog#1963](https://github.com/Seldaek/monolog/pull/1963)). This calls `fileinode()` before each write, which triggers PHP to invoke `url_stat` on the stream wrapper.

This caused two issues:

1. `FakeTcpStream` didn't implement `url_stat`, causing a runtime exception
2. PHP creates a **new** stream wrapper instance for each `url_stat` call. Since registration happened in the constructor, these temporary instances were being added to the `instances()` collection, inflating the count

### Solution

1. Add `url_stat` handler that returns `false` (indicating no stat info available for TCP streams)
2. Move instance registration from the constructor to the `stream_open` handler, so only actual stream connections are tracked
