### PR TITLE
Add rejectRequests() method for filtering request records.

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -500,6 +500,12 @@ trait CapturesState
     {
         [$record, $resolver] = $this->sensor->request($request, $response);
 
+        foreach ($this->rejectRequestCallbacks as $callback) {
+            if ($this->ignore(static fn () => ($callback)($record))) {
+                return;
+            }
+        }
+
         foreach ($this->redactRequestCallbacks as $callback) {
             $this->ignore(static fn () => ($callback)($record));
         }

--- a/src/Concerns/RejectsRecords.php
+++ b/src/Concerns/RejectsRecords.php
@@ -8,6 +8,7 @@ use Laravel\Nightwatch\Records\Notification;
 use Laravel\Nightwatch\Records\OutgoingRequest;
 use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\Records\QueuedJob;
+use Laravel\Nightwatch\Records\Request;
 
 /**
  * @internal
@@ -50,6 +51,11 @@ trait RejectsRecords
      * @var list<callable(QueuedJob): bool>
      */
     private array $rejectQueuedJobCallbacks = [];
+
+    /**
+     * @var list<callable(Request): bool>
+     */
+    private array $rejectRequestCallbacks = [];
 
     /**
      * @api
@@ -148,5 +154,15 @@ trait RejectsRecords
     public function rejectQueuedJobs(callable $callback): void
     {
         $this->rejectQueuedJobCallbacks[] = $callback;
+    }
+
+    /**
+     * @api
+     *
+     * @param  callable(Request): bool  $callback
+     */
+    public function rejectRequests(callable $callback): void
+    {
+        $this->rejectRequestCallbacks[] = $callback;
     }
 }

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -36,6 +36,7 @@ use function preg_replace;
 use function report;
 use function str_contains;
 use function str_replace;
+use function str_starts_with;
 
 class FilteringTest extends TestCase
 {
@@ -451,6 +452,28 @@ class FilteringTest extends TestCase
             return true;
         });
         $ingest->assertLatestWrite('queued-job:0.name', SampledJob::class);
+    }
+
+    public function test_it_can_filter_requests(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/health', fn () => 'ok');
+        Route::get('/api/users', fn () => 'users');
+        Route::get('/dashboard', fn () => 'dashboard');
+
+        Nightwatch::rejectRequests(fn (Request $request) => $request->routePath === '/health');
+        Nightwatch::rejectRequests(fn (Request $request) => str_starts_with($request->routePath, '/api'));
+
+        $this->get('/health');
+        $ingest->forgetWrites();
+
+        $this->get('/api/users');
+        $ingest->forgetWrites();
+
+        $this->get('/dashboard');
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('request:0.route_path', '/dashboard');
     }
 
     public function test_it_does_not_trigger_recursion_while_filtering()


### PR DESCRIPTION
## Summary

Add a `rejectRequests()` method to allow users to exclude specific routes/paths from being recorded by Nightwatch, following the established pattern used for other record types (queries, cache events, mail, notifications, outgoing requests, queued jobs).

## Motivation

Currently, requests only support **redaction** (`redactRequests()`) for sanitizing data, but not **rejection** for excluding requests entirely. This is inconsistent with other record types and makes it difficult to filter out noise from health checks, internal routes, or high-frequency endpoints.

## Usage Examples

```php
// In a service provider boot() method:

use Laravel\Nightwatch\Facades\Nightwatch;
use Laravel\Nightwatch\Records\Request;

// Reject health check endpoints
Nightwatch::rejectRequests(fn (Request $request) => $request->routePath === '/health');

// Reject by route name
Nightwatch::rejectRequests(fn (Request $request) => $request->routeName === 'horizon.stats');

// Reject internal API routes
Nightwatch::rejectRequests(fn (Request $request) => str_starts_with($request->routePath, '/api/internal'));

// Reject by status code (e.g., not modified responses)
Nightwatch::rejectRequests(fn (Request $request) => $request->statusCode === 304);

// Reject multiple patterns at once
Nightwatch::rejectRequests(function (Request $request) {
    return in_array($request->routePath, ['/health', '/ready', '/metrics', '/_debugbar']);
});
```

## Available Request Properties for Filtering

- `routePath` - The route pattern (e.g., `/users/{id}`)
- `routeName` - The route name (e.g., `users.show`)
- `url` - The full URL
- `method` - HTTP method (GET, POST, etc.)
- `routeAction` - Controller action
- `statusCode` - HTTP response status code