### PR TITLE
NW-1694 Add support for capturing laravel/ai events

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,3 +8,11 @@ parameters:
       path: src/Ingest.php
       count: 1
       reportUnmatched: false
+    # Laravel AI package is optional and unpublished - ignore all related errors
+    -
+      message: '#Laravel\\Ai\\#'
+      reportUnmatched: false
+    -
+      identifier: 'property.nonObject'
+      path: src/Sensors/AiEventSensor.php
+      reportUnmatched: false

--- a/src/Compatibility.php
+++ b/src/Compatibility.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Context;
 use ReflectionProperty;
 use Symfony\Component\Console\Input\ArgvInput;
 
+use function class_exists;
 use function implode;
 use function method_exists;
 use function tap;
@@ -40,6 +41,8 @@ final class Compatibility
     public static bool $subMinuteScheduledTasksSupported = false;
 
     public static bool $queryConnectionTypeCapturable = false;
+
+    public static bool $aiEventsAvailable = false;
 
     /**
      * @var array{
@@ -121,6 +124,11 @@ final class Compatibility
          * @see https://github.com/laravel/framework/releases/tag/v12.45.0
          */
         self::$queryConnectionTypeCapturable = version_compare($version, '12.45.0', '>=');
+
+        /**
+         * @see https://github.com/laravel/ai
+         */
+        self::$aiEventsAvailable = class_exists(\Laravel\Ai\Events\AgentPrompted::class);
     }
 
     /**

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -22,6 +22,20 @@ use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
 use Illuminate\Routing\Route;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\AudioGenerated;
+use Laravel\Ai\Events\EmbeddingsGenerated;
+use Laravel\Ai\Events\GeneratingAudio;
+use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Events\GeneratingImage;
+use Laravel\Ai\Events\GeneratingTranscription;
+use Laravel\Ai\Events\ImageGenerated;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\StreamingAgent;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Events\TranscriptionGenerated;
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\ExecutionStage;
@@ -449,6 +463,32 @@ trait CapturesState
         foreach ($this->redactCacheEventCallbacks as $callback) {
             $this->ignore(static fn () => ($callback)($record));
         }
+
+        $this->ingest->write($resolver());
+    }
+
+    /**
+     * @internal
+     */
+    public function aiEvent(
+        PromptingAgent|StreamingAgent|AgentPrompted|AgentStreamed|
+        InvokingTool|ToolInvoked|
+        GeneratingAudio|AudioGenerated|
+        GeneratingEmbeddings|EmbeddingsGenerated|
+        GeneratingImage|ImageGenerated|
+        GeneratingTranscription|TranscriptionGenerated $event
+    ): void {
+        if ($this->paused) {
+            return;
+        }
+
+        $aiEvent = $this->sensor->aiEvent($event);
+
+        if ($aiEvent === null) {
+            return;
+        }
+
+        [$record, $resolver] = $aiEvent;
 
         $this->ingest->write($resolver());
     }

--- a/src/Hooks/AiEventListener.php
+++ b/src/Hooks/AiEventListener.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\Nightwatch\Hooks;
+
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\AudioGenerated;
+use Laravel\Ai\Events\EmbeddingsGenerated;
+use Laravel\Ai\Events\GeneratingAudio;
+use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Events\GeneratingImage;
+use Laravel\Ai\Events\GeneratingTranscription;
+use Laravel\Ai\Events\ImageGenerated;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\StreamingAgent;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Events\TranscriptionGenerated;
+use Laravel\Nightwatch\Core;
+use Laravel\Nightwatch\State\CommandState;
+use Laravel\Nightwatch\State\RequestState;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class AiEventListener
+{
+    /**
+     * @param  Core<RequestState|CommandState>  $nightwatch
+     */
+    public function __construct(
+        private Core $nightwatch,
+    ) {
+        //
+    }
+
+    public function __invoke(
+        PromptingAgent|StreamingAgent|AgentPrompted|AgentStreamed|
+        InvokingTool|ToolInvoked|
+        GeneratingAudio|AudioGenerated|
+        GeneratingEmbeddings|EmbeddingsGenerated|
+        GeneratingImage|ImageGenerated|
+        GeneratingTranscription|TranscriptionGenerated $event
+    ): void {
+        try {
+            $this->nightwatch->aiEvent($event);
+        } catch (Throwable $e) {
+            $this->nightwatch->report($e, handled: true);
+        }
+    }
+}

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -39,9 +39,24 @@ use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\AudioGenerated;
+use Laravel\Ai\Events\EmbeddingsGenerated;
+use Laravel\Ai\Events\GeneratingAudio;
+use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Events\GeneratingImage;
+use Laravel\Ai\Events\GeneratingTranscription;
+use Laravel\Ai\Events\ImageGenerated;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\StreamingAgent;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Events\TranscriptionGenerated;
 use Laravel\Nightwatch\Console\AgentCommand;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Factories\Logger;
+use Laravel\Nightwatch\Hooks\AiEventListener;
 use Laravel\Nightwatch\Hooks\ArtisanStartingListener;
 use Laravel\Nightwatch\Hooks\CacheEventListener;
 use Laravel\Nightwatch\Hooks\CommandBootedHandler;
@@ -365,6 +380,28 @@ final class NightwatchServiceProvider extends ServiceProvider
         ], (new CacheEventListener($core))(...));
 
         $events->listen(RequestReceived::class, (new OctaneListener($core))(...)); // @phpstan-ignore class.notFound
+
+        /**
+         * @see \Laravel\Nightwatch\Records\AiEvent
+         */
+        if (Compatibility::$aiEventsAvailable) {
+            $events->listen([
+                PromptingAgent::class,
+                StreamingAgent::class,
+                AgentPrompted::class,
+                AgentStreamed::class,
+                InvokingTool::class,
+                ToolInvoked::class,
+                GeneratingAudio::class,
+                AudioGenerated::class,
+                GeneratingEmbeddings::class,
+                EmbeddingsGenerated::class,
+                GeneratingImage::class,
+                ImageGenerated::class,
+                GeneratingTranscription::class,
+                TranscriptionGenerated::class,
+            ], (new AiEventListener($core))(...));
+        }
 
         Queue::createPayloadUsing(new CreateQueuePayloadHandler($core));
 

--- a/src/Records/AiEvent.php
+++ b/src/Records/AiEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Laravel\Nightwatch\Records;
+
+/**
+ * @internal
+ */
+final class AiEvent
+{
+    public function __construct(
+        public readonly string $operation,
+        public readonly string $invocationId,
+        public readonly string $toolInvocationId,
+        public readonly string $provider,
+        public readonly string $model,
+        public readonly string $agent,
+        public readonly string $tool,
+        public readonly int $promptTokens,
+        public readonly int $completionTokens,
+        public readonly int $cacheReadTokens,
+        public readonly int $cacheWriteTokens,
+        public readonly int $reasoningTokens,
+        public readonly int $duration,
+        public readonly bool $failed,
+    ) {
+        //
+    }
+}

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -18,6 +18,21 @@ use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobQueued;
 use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Events\JobReleasedAfterException;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\AudioGenerated;
+use Laravel\Ai\Events\EmbeddingsGenerated;
+use Laravel\Ai\Events\GeneratingAudio;
+use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Events\GeneratingImage;
+use Laravel\Ai\Events\GeneratingTranscription;
+use Laravel\Ai\Events\ImageGenerated;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\StreamingAgent;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Events\TranscriptionGenerated;
+use Laravel\Nightwatch\Records\AiEvent;
 use Laravel\Nightwatch\Records\CacheEvent as CacheEventRecord;
 use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Exception;
@@ -27,6 +42,7 @@ use Laravel\Nightwatch\Records\OutgoingRequest;
 use Laravel\Nightwatch\Records\Query;
 use Laravel\Nightwatch\Records\QueuedJob;
 use Laravel\Nightwatch\Records\Request as RequestRecord;
+use Laravel\Nightwatch\Sensors\AiEventSensor;
 use Laravel\Nightwatch\Sensors\CacheEventSensor;
 use Laravel\Nightwatch\Sensors\CommandSensor;
 use Laravel\Nightwatch\Sensors\ExceptionSensor;
@@ -127,6 +143,11 @@ final class SensorManager
      * @var (callable(InputInterface, int): array{0: Command, 1: callable(): array<mixed>})|null
      */
     public $commandSensor;
+
+    /**
+     * @var (callable(PromptingAgent|StreamingAgent|AgentPrompted|AgentStreamed|InvokingTool|ToolInvoked|GeneratingAudio|AudioGenerated|GeneratingEmbeddings|EmbeddingsGenerated|GeneratingImage|ImageGenerated|GeneratingTranscription|TranscriptionGenerated): ?array{0: AiEvent, 1: callable(): array<mixed>})|null
+     */
+    public $aiEventSensor;
 
     /**
      * @param  list<string>  $redactPayloadFields
@@ -361,6 +382,25 @@ final class SensorManager
         return $sensor();
     }
 
+    /**
+     * @return ?array{0: AiEvent, 1: callable(): array<mixed>}
+     */
+    public function aiEvent(
+        PromptingAgent|StreamingAgent|AgentPrompted|AgentStreamed|
+        InvokingTool|ToolInvoked|
+        GeneratingAudio|AudioGenerated|
+        GeneratingEmbeddings|EmbeddingsGenerated|
+        GeneratingImage|ImageGenerated|
+        GeneratingTranscription|TranscriptionGenerated $event
+    ): ?array {
+        $sensor = $this->aiEventSensor ??= new AiEventSensor(
+            executionState: $this->executionState,
+            clock: $this->clock,
+        );
+
+        return $sensor($event);
+    }
+
     public function flush(): void
     {
         $this->cacheEventSensor = null;
@@ -377,5 +417,6 @@ final class SensorManager
         $this->scheduledTaskSensor = null;
         $this->requestSensor = null;
         $this->commandSensor = null;
+        $this->aiEventSensor = null;
     }
 }

--- a/src/Sensors/AiEventSensor.php
+++ b/src/Sensors/AiEventSensor.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Laravel\Nightwatch\Sensors;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\AudioGenerated;
+use Laravel\Ai\Events\EmbeddingsGenerated;
+use Laravel\Ai\Events\GeneratingAudio;
+use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Events\GeneratingImage;
+use Laravel\Ai\Events\GeneratingTranscription;
+use Laravel\Ai\Events\ImageGenerated;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\StreamingAgent;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Events\TranscriptionGenerated;
+use Laravel\Ai\Providers\Provider;
+use Laravel\Ai\Responses\Data\Usage;
+use Laravel\Nightwatch\Clock;
+use Laravel\Nightwatch\Records\AiEvent;
+use Laravel\Nightwatch\State\CommandState;
+use Laravel\Nightwatch\State\RequestState;
+use Laravel\Nightwatch\Types\Str;
+use RuntimeException;
+
+use function hash;
+use function method_exists;
+use function round;
+
+/**
+ * @internal
+ */
+final class AiEventSensor
+{
+    /**
+     * @var array<string, float>
+     */
+    private array $startTimes = [];
+
+    /**
+     * @var array<string, array{provider: string, model: string}>
+     */
+    private array $startContext = [];
+
+    public function __construct(
+        private RequestState|CommandState $executionState,
+        private Clock $clock,
+    ) {
+        //
+    }
+
+    /**
+     * @return ?array{0: AiEvent, 1: callable(): array<mixed>}
+     */
+    public function __invoke(
+        PromptingAgent|StreamingAgent|AgentPrompted|AgentStreamed|
+        InvokingTool|ToolInvoked|
+        GeneratingAudio|AudioGenerated|
+        GeneratingEmbeddings|EmbeddingsGenerated|
+        GeneratingImage|ImageGenerated|
+        GeneratingTranscription|TranscriptionGenerated $event
+    ): ?array {
+        $now = $this->clock->microtime();
+
+        // Handle start events
+        if ($event instanceof PromptingAgent || $event instanceof StreamingAgent) {
+            $this->startTimes[$event->invocationId] = $now;
+
+            return null;
+        }
+
+        if ($event instanceof InvokingTool) {
+            $this->startTimes[$event->toolInvocationId] = $now;
+
+            return null;
+        }
+
+        if ($event instanceof GeneratingAudio ||
+            $event instanceof GeneratingEmbeddings ||
+            $event instanceof GeneratingImage ||
+            $event instanceof GeneratingTranscription) {
+            $this->startTimes[$event->invocationId] = $now;
+            $this->startContext[$event->invocationId] = [
+                'provider' => $event->provider->name(),
+                'model' => $event->model,
+            ];
+
+            return null;
+        }
+
+        // Handle end events
+        return match (true) {
+            $event instanceof AgentPrompted, $event instanceof AgentStreamed => $this->handleAgentResponse($event, $now),
+            $event instanceof ToolInvoked => $this->handleToolInvoked($event, $now),
+            $event instanceof AudioGenerated => $this->handleGeneration($event, 'audio_generation', $now),
+            $event instanceof EmbeddingsGenerated => $this->handleGeneration($event, 'embeddings_generation', $now),
+            $event instanceof ImageGenerated => $this->handleGeneration($event, 'image_generation', $now),
+            $event instanceof TranscriptionGenerated => $this->handleGeneration($event, 'transcription_generation', $now),
+        };
+    }
+
+    /**
+     * @return array{0: AiEvent, 1: callable(): array<mixed>}
+     */
+    private function handleAgentResponse(AgentPrompted|AgentStreamed $event, float $now): array
+    {
+        $startTime = $this->startTimes[$event->invocationId] ?? null;
+
+        if ($startTime === null) {
+            throw new RuntimeException("No start time found for agent invocation [{$event->invocationId}].");
+        }
+
+        unset($this->startTimes[$event->invocationId]);
+
+        $usage = $event->response->usage;
+        $meta = $event->response->meta;
+
+        return $this->buildRecord(
+            operation: $event instanceof AgentStreamed ? 'agent_stream' : 'agent_prompt',
+            invocationId: $event->invocationId,
+            toolInvocationId: '',
+            provider: $meta->provider ?? '',
+            model: $meta->model ?? '',
+            agent: '',
+            tool: '',
+            usage: $usage,
+            duration: (int) round(($now - $startTime) * 1_000_000),
+            failed: false,
+            now: $now,
+        );
+    }
+
+    /**
+     * @return array{0: AiEvent, 1: callable(): array<mixed>}
+     */
+    private function handleToolInvoked(ToolInvoked $event, float $now): array
+    {
+        $startTime = $this->startTimes[$event->toolInvocationId] ?? null;
+
+        if ($startTime === null) {
+            throw new RuntimeException("No start time found for tool invocation [{$event->toolInvocationId}].");
+        }
+
+        unset($this->startTimes[$event->toolInvocationId]);
+
+        return $this->buildRecord(
+            operation: 'tool_invocation',
+            invocationId: $event->invocationId,
+            toolInvocationId: $event->toolInvocationId,
+            provider: '',
+            model: '',
+            agent: $this->getClassName($event->agent),
+            tool: $this->getClassName($event->tool),
+            usage: null,
+            duration: (int) round(($now - $startTime) * 1_000_000),
+            failed: false,
+            now: $now,
+        );
+    }
+
+    /**
+     * @return array{0: AiEvent, 1: callable(): array<mixed>}
+     */
+    private function handleGeneration(
+        AudioGenerated|EmbeddingsGenerated|ImageGenerated|TranscriptionGenerated $event,
+        string $operation,
+        float $now
+    ): array {
+        $startTime = $this->startTimes[$event->invocationId] ?? null;
+        $context = $this->startContext[$event->invocationId] ?? null;
+
+        if ($startTime === null) {
+            throw new RuntimeException("No start time found for generation [{$event->invocationId}].");
+        }
+
+        unset($this->startTimes[$event->invocationId], $this->startContext[$event->invocationId]);
+
+        // Get usage if available on response
+        $usage = method_exists($event->response, 'usage') ? $event->response->usage : null;
+
+        return $this->buildRecord(
+            operation: $operation,
+            invocationId: $event->invocationId,
+            toolInvocationId: '',
+            provider: $context['provider'] ?? $event->provider->name(),
+            model: $context['model'] ?? $event->model,
+            agent: '',
+            tool: '',
+            usage: $usage instanceof Usage ? $usage : null,
+            duration: (int) round(($now - $startTime) * 1_000_000),
+            failed: false,
+            now: $now,
+        );
+    }
+
+    /**
+     * @return array{0: AiEvent, 1: callable(): array<mixed>}
+     */
+    private function buildRecord(
+        string $operation,
+        string $invocationId,
+        string $toolInvocationId,
+        string $provider,
+        string $model,
+        string $agent,
+        string $tool,
+        ?Usage $usage,
+        int $duration,
+        bool $failed,
+        float $now,
+    ): array {
+        return [
+            $record = new AiEvent(
+                operation: $operation,
+                invocationId: $invocationId,
+                toolInvocationId: $toolInvocationId,
+                provider: $provider,
+                model: $model,
+                agent: $agent,
+                tool: $tool,
+                promptTokens: $usage?->promptTokens ?? 0,
+                completionTokens: $usage?->completionTokens ?? 0,
+                cacheReadTokens: $usage?->cacheReadInputTokens ?? 0,
+                cacheWriteTokens: $usage?->cacheWriteInputTokens ?? 0,
+                reasoningTokens: $usage?->reasoningTokens ?? 0,
+                duration: $duration,
+                failed: $failed,
+            ),
+            function () use ($now, $record) {
+                $this->executionState->aiEvents++;
+
+                return [
+                    'v' => 1,
+                    't' => 'ai-event',
+                    'timestamp' => $now,
+                    'deploy' => $this->executionState->deploy,
+                    'server' => $this->executionState->server,
+                    '_group' => hash('xxh128', $record->operation.','.$record->provider.','.$record->model.','.$record->agent.','.$record->tool),
+                    'trace_id' => $this->executionState->trace,
+                    'execution_source' => $this->executionState->source,
+                    'execution_id' => $this->executionState->id(),
+                    'execution_preview' => $this->executionState->executionPreview(),
+                    'execution_stage' => $this->executionState->stage,
+                    'user' => $this->executionState->user->id(),
+                    // --- //
+                    'operation' => Str::tinyText($record->operation),
+                    'invocation_id' => Str::tinyText($record->invocationId),
+                    'tool_invocation_id' => Str::tinyText($record->toolInvocationId),
+                    'provider' => Str::tinyText($record->provider),
+                    'model' => Str::tinyText($record->model),
+                    'agent' => Str::tinyText($record->agent),
+                    'tool' => Str::tinyText($record->tool),
+                    'prompt_tokens' => $record->promptTokens,
+                    'completion_tokens' => $record->completionTokens,
+                    'cache_read_tokens' => $record->cacheReadTokens,
+                    'cache_write_tokens' => $record->cacheWriteTokens,
+                    'reasoning_tokens' => $record->reasoningTokens,
+                    'duration' => $record->duration,
+                    'failed' => $record->failed,
+                ];
+            },
+        ];
+    }
+
+    private function getClassName(Agent|Tool $object): string
+    {
+        return $object::class;
+    }
+}

--- a/src/State/CommandState.php
+++ b/src/State/CommandState.php
@@ -61,6 +61,7 @@ final class CommandState
         public int $filesWritten = 0,
         public int $cacheEvents = 0,
         public int $hydratedModels = 0,
+        public int $aiEvents = 0,
         public string $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION,
         public string $laravelVersion = Application::VERSION,
         public ?Artisan $artisan = null,
@@ -117,6 +118,7 @@ final class CommandState
         $this->filesWritten = 0;
         $this->cacheEvents = 0;
         $this->hydratedModels = 0;
+        $this->aiEvents = 0;
         $this->exceptionPreview = '';
     }
 }

--- a/src/State/RequestState.php
+++ b/src/State/RequestState.php
@@ -64,6 +64,7 @@ final class RequestState
         public int $filesWritten = 0,
         public int $cacheEvents = 0,
         public int $hydratedModels = 0,
+        public int $aiEvents = 0,
         public string $phpVersion = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION,
         public string $laravelVersion = Application::VERSION,
         public string $executionPreview = '',
@@ -118,6 +119,7 @@ final class RequestState
         $this->filesWritten = 0;
         $this->cacheEvents = 0;
         $this->hydratedModels = 0;
+        $this->aiEvents = 0;
         $this->executionPreview = '';
         $this->exceptionPreview = '';
         $this->user->flush();


### PR DESCRIPTION
## Summary

Adds foundational support for capturing events from the `laravel/ai` package. AI events (prompts, responses, tool invocations, audio generation, etc.) are now tracked.

## Changes

- Add `AiEvent` record class for storing AI event data
- Add `AiEventSensor` to handle event lifecycle (start/end) and calculate duration
- Add `AiEventListener` hook with proper error handling
- Wire through `SensorManager` and `CapturesState`
- Add `aiEvents` counter to `RequestState` and `CommandState`
- Add `Compatibility::$aiEventsAvailable` flag for conditional registration
- Update PHPStan config to ignore optional `Laravel\Ai` dependency