### PR TITLE
Fix sampling rate being ignored due to context side-effect in ignore()

### DIFF
--- a/src/Compatibility.php
+++ b/src/Compatibility.php
@@ -137,7 +137,7 @@ final class Compatibility
         return implode(' ', $tokens);
     }
 
-    public static function addSamplingToContext(bool $sample): void
+    public static function addSamplingToContext(?bool $sample): void
     {
         self::addHiddenContext('nightwatch_should_sample', $sample);
     }

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -197,7 +197,7 @@ trait CapturesState
     public function ignore(callable $callback): mixed
     {
         $cachedPaused = $this->paused;
-        $cachedSamplingInContext = Compatibility::getSamplingFromContext();
+        $cachedSamplingInContext = Compatibility::getSamplingFromContext(null);
 
         try {
             $this->paused = true;

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -13,6 +13,7 @@ use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Console\Sample;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
@@ -249,6 +250,7 @@ class CliSamplingTest extends TestCase
         $this->assertEqualsWithDelta(50, $samples, 20);
     }
 
+    #[RunInSeparateProcess]
     #[DataProvider('commandSamplingRates')]
     public function test_it_applies_configured_command_sample_rate(int $rate, bool $expected): void
     {

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -249,6 +249,20 @@ class CliSamplingTest extends TestCase
         $this->assertEqualsWithDelta(50, $samples, 20);
     }
 
+    #[DataProvider('commandSamplingRates')]
+    public function test_it_applies_configured_command_sample_rate(int $rate, bool $expected): void
+    {
+        $this->core->config['sampling']['commands'] = $rate;
+        Nightwatch::configureCommandSampling('app:example');
+        $this->assertSame($expected, Nightwatch::sampling());
+    }
+
+    public static function commandSamplingRates(): iterable
+    {
+        yield 'not sampling' => [0, false];
+        yield 'sampling' => [1, true];
+    }
+
     public static function vendorCommands(): iterable
     {
         yield ['auth:clear-resets'];


### PR DESCRIPTION
## Summary

Fixes command sampling rate not taking effect.

## Synopsis

During boot, Laravel fires database queries and cache events before command sampling is configured. The sensors handling these events call ignore(), which invokes getSamplingFromContext() with a default of true. Since no sampling value exists in the context yet, this default is returned and then written back via addSamplingToContext(true) in the finally block.

When configureCommandSampling later runs on CommandStarting, it calls getSamplingFromContext(null), finds the stored true value, interprets it as "a previous stage already decided to sample" (true => 1.0), and skips the configured rate entirely. A sample rate of 0.1 would never be applied.

Fix by passing null to getSamplingFromContext() in ignore(), so it reads the context without initializing it when empty. Also update addSamplingToContext() to accept nullable bool for consistency.

## Testing

A test case was added at a high level to verify global sample rates are used when existing context is absent. We test both 0 and 1 to catch any bug that might disable capture of all events, as well as any bug that might enable capture of all events (such as the one being fixed).

## Context

We recently ran out of allocated events for our Nightwatch plan. When we began comparing data against previous months, we saw the number of recorded commands increased 10x. We had been using a configured command rate of 0.1.

When we investigated the cause, we saw this corresponded to a deployment that updated Laravel Nightwatch from 1.19.0 to 1.21.0.

At the time, we experienced an issue with increased scheduled task sampling that was caused by the introduction of the new NIGHTWATCH_SCHEDULED_TASK_SAMPLE_RATE environment variable. While we fixed the scheduled task sample rate by adding the variable to our environments, we observed the sample rate for commands still seemed to be 100% instead of the configured 10%. 

## Culprit

This appears to have been introduced by #308, and was included in the 1.20.0 release.