### PR TITLE
Ensure `Nightwatch::ignore` does not override sampling when unset

### DIFF
--- a/src/Compatibility.php
+++ b/src/Compatibility.php
@@ -142,6 +142,11 @@ final class Compatibility
         self::addHiddenContext('nightwatch_should_sample', $sample);
     }
 
+    public static function removeSamplingFromContext(): void
+    {
+        self::addHiddenContext('nightwatch_should_sample', null);
+    }
+
     /**
      * @template T of bool|null
      *

--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -197,7 +197,7 @@ trait CapturesState
     public function ignore(callable $callback): mixed
     {
         $cachedPaused = $this->paused;
-        $cachedSamplingInContext = Compatibility::getSamplingFromContext();
+        $cachedSamplingInContext = Compatibility::getSamplingFromContext(null);
 
         try {
             $this->paused = true;
@@ -206,7 +206,12 @@ trait CapturesState
             return $callback();
         } finally {
             $this->paused = $cachedPaused;
-            Compatibility::addSamplingToContext($cachedSamplingInContext);
+
+            if ($cachedSamplingInContext === null) {
+                Compatibility::removeSamplingFromContext();
+            } else {
+                Compatibility::addSamplingToContext($cachedSamplingInContext);
+            }
         }
     }
 

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -732,16 +732,22 @@ class FilteringTest extends TestCase
 
     public function test_it_restores_context_sampling_state_when_ignoring(): void
     {
+        Compatibility::removeSamplingFromContext();
+
+        Nightwatch::ignore(fn () => null);
+
+        $this->assertNull(Compatibility::getSamplingFromContext(null));
+
         Compatibility::addSamplingToContext(true);
 
         Nightwatch::ignore(fn () => null);
 
-        $this->assertTrue(Compatibility::getSamplingFromContext());
+        $this->assertTrue(Compatibility::getSamplingFromContext(null));
 
         Compatibility::addSamplingToContext(false);
 
         Nightwatch::ignore(fn () => null);
 
-        $this->assertFalse(Compatibility::getSamplingFromContext());
+        $this->assertFalse(Compatibility::getSamplingFromContext(null));
     }
 }


### PR DESCRIPTION
When calling `ignore`, the sampling in context will always be set. This is unexpected if the current sampling in context is `null`.

## Before

```php
Context::getHidden('nightwatch_should_sample'); // null

Nightwatch::ignore(function () {
    //
});

Context::getHidden('nightwatch_should_sample'); // true
```

## After

```php
Context::getHidden('nightwatch_should_sample'); // null

Nightwatch::ignore(function () {
    //
});

Context::getHidden('nightwatch_should_sample'); // null
```