### PR TITLE
Allow logs to bubble up through other channels in the stack

### DIFF
--- a/src/Hooks/LogHandler.php
+++ b/src/Hooks/LogHandler.php
@@ -58,7 +58,7 @@ final class LogHandler implements HandlerInterface
 
             $this->nightwatch->log($record);
 
-            return true;
+            return false;
         } catch (Throwable $e) {
             $this->nightwatch->report($e, handled: true);
 

--- a/tests/Unit/Hooks/LogRecordProcessorTest.php
+++ b/tests/Unit/Hooks/LogRecordProcessorTest.php
@@ -42,12 +42,19 @@ class LogRecordProcessorTest extends TestCase
         $this->travelTo(Date::parse('2000-01-01 00:00:00'));
         $streams = $this->fakeTcpStreams();
         Config::set([
-            'logging.channels.stack.channels' => ['log-stream', 'nightwatch'],
-            'logging.channels.log-stream' => [
+            'logging.channels.stack.channels' => ['log-stream-before', 'nightwatch', 'log-stream-after'],
+            'logging.channels.log-stream-before' => [
                 'driver' => 'monolog',
                 'handler' => \Monolog\Handler\StreamHandler::class,
                 'handler_with' => [
-                    'stream' => 'tcp://log-stream',
+                    'stream' => 'tcp://log-stream-before',
+                ],
+            ],
+            'logging.channels.log-stream-after' => [
+                'driver' => 'monolog',
+                'handler' => \Monolog\Handler\StreamHandler::class,
+                'handler_with' => [
+                    'stream' => 'tcp://log-stream-after',
                 ],
             ],
         ]);
@@ -57,10 +64,11 @@ class LogRecordProcessorTest extends TestCase
         ]);
         $this->core->finishExecution();
 
-        $this->assertCount(2, $streams);
-        [$log, $ingest] = $streams;
+        $this->assertCount(3, $streams);
+        [$before, $after, $ingest] = $streams;
 
-        $this->assertStringContainsString('{"now":"2000-01-01 11:00:00"}', $log->value);
+        $this->assertStringContainsString('{"now":"2000-01-01 11:00:00"}', $before->value);
+        $this->assertStringContainsString('{"now":"2000-01-01 11:00:00"}', $after->value);
         $this->assertStringContainsString('{\"now\":\"2000-01-01 00:00:00.000000+00:00\"}', $ingest->value);
     }
 


### PR DESCRIPTION
replaces https://github.com/laravel/nightwatch/pull/297

Sets a sensible default to allow logs to bubble up through other channels in the stack.

Right now, when Nightwatch captures the log, no subsequent channels will receive the log, e.g., 

```
Log::stack(['before', 'nightwatch', 'after'])->info('test');
```

In the above example, both `before` and `nightwatch` will get the log, but `after` will not.

Allowing the log to bubble up is a saner default for Nightwatch. We can investigate adding configuration for this (see `bubble` option of Monolog) at a later date if there is demand.