### PR TITLE
Restore local dependencies after running the build command

### DIFF
--- a/agent/composer.json
+++ b/agent/composer.json
@@ -62,7 +62,8 @@
             "@php vendor/bin/phpunit"
         ],
         "build": [
-            "bash ./build.sh"
+            "bash ./build.sh",
+            "([ ! \"${CI}\" ] && composer install) || true"
         ],
         "watch": [
             "npm ci",


### PR DESCRIPTION
Every time we run `composer ci` (or `composer build`) locally, we lose our dev dependencies. I run these a lot when working on the package.

Adding another command to reinstall dependencies locally after building.