### PR TITLE
Add VAPOR_COMMIT_HASH fallback for NIGHTWATCH_DEPLOY

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -3,7 +3,7 @@
 return [
     'enabled' => env('NIGHTWATCH_ENABLED', true),
     'token' => env('NIGHTWATCH_TOKEN'),
-    'deployment' => env('NIGHTWATCH_DEPLOY', env('LARAVEL_CLOUD_COMMIT', env('FORGE_DEPLOY_COMMIT'))),
+    'deployment' => env('NIGHTWATCH_DEPLOY', env('LARAVEL_CLOUD_COMMIT', env('FORGE_DEPLOY_COMMIT', env('VAPOR_COMMIT_HASH')))),
     'server' => env('NIGHTWATCH_SERVER', (string) gethostname()),
     'capture_exception_source_code' => env('NIGHTWATCH_CAPTURE_EXCEPTION_SOURCE_CODE', true),
     'capture_request_payload' => env('NIGHTWATCH_CAPTURE_REQUEST_PAYLOAD', false),

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -151,4 +151,19 @@ class CoreTest extends TestCase
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('request:0.deploy', '12f35860d8c7e59fe4d81a3256a2bb34c998acd9');
     }
+
+    #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]
+    #[WithEnv('VAPOR_COMMIT_HASH', '02f35860d8c7e59fe4d81a3256a2bb34c998acd9')]
+    public function test_it_uses_vapor_commit_hash_for_deployments_if_available(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/test', function () {
+            return 'OK';
+        });
+
+        $this->get('/test')->assertOk();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('request:0.deploy', '02f35860d8c7e59fe4d81a3256a2bb34c998acd9');
+    }
 }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This adds the Laravel Vapor commit hash env var fallback similar to Cloud and Forge
