### PR TITLE
Switch to unique deploy UUID for deployment config

### DIFF
--- a/config/nightwatch.php
+++ b/config/nightwatch.php
@@ -3,7 +3,7 @@
 return [
     'enabled' => env('NIGHTWATCH_ENABLED', true),
     'token' => env('NIGHTWATCH_TOKEN'),
-    'deployment' => env('NIGHTWATCH_DEPLOY', env('LARAVEL_CLOUD_COMMIT', env('FORGE_DEPLOY_COMMIT', env('VAPOR_COMMIT_HASH')))),
+    'deployment' => env('NIGHTWATCH_DEPLOY', env('LARAVEL_CLOUD_DEPLOY_UUID', env('FORGE_DEPLOY_COMMIT', env('VAPOR_COMMIT_HASH')))),
     'server' => env('NIGHTWATCH_SERVER', (string) gethostname()),
     'capture_exception_source_code' => env('NIGHTWATCH_CAPTURE_EXCEPTION_SOURCE_CODE', true),
     'capture_request_payload' => env('NIGHTWATCH_CAPTURE_REQUEST_PAYLOAD', false),

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -107,7 +107,7 @@ class CoreTest extends TestCase
     }
 
     #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]
-    #[WithEnv('LARAVEL_CLOUD_DEPLOY_UUID', '92f35860d8c7e59fe4d81a3256a2bb34c998acd9')]
+    #[WithEnv('LARAVEL_CLOUD_DEPLOY_UUID', 'cca312d8-2b81-45c1-822b-3ff0bf944c2c')]
     public function test_it_uses_cloud_commit_env_for_deployments_if_available(): void
     {
         $ingest = $this->fakeIngest();
@@ -118,7 +118,7 @@ class CoreTest extends TestCase
         $this->get('/test')->assertOk();
 
         $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('request:0.deploy', '92f35860d8c7e59fe4d81a3256a2bb34c998acd9');
+        $ingest->assertLatestWrite('request:0.deploy', 'cca312d8-2b81-45c1-822b-3ff0bf944c2c');
     }
 
     #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -107,7 +107,7 @@ class CoreTest extends TestCase
     }
 
     #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]
-    #[WithEnv('LARAVEL_CLOUD_COMMIT', '92f35860d8c7e59fe4d81a3256a2bb34c998acd9')]
+    #[WithEnv('LARAVEL_CLOUD_DEPLOY_UUID', '92f35860d8c7e59fe4d81a3256a2bb34c998acd9')]
     public function test_it_uses_cloud_commit_env_for_deployments_if_available(): void
     {
         $ingest = $this->fakeIngest();


### PR DESCRIPTION
Laravel Cloud can deploy the same commit version multiple times. This happens when changing environment settings. By using only the commit hash for Nightwatch deployment config, we are not able to track those changes separately although they may contribute to issues.

By changing the default deployment to the Cloud deployment UUID, we have more granularity in deployment tracking for attributing issues to changes in environment, whether it is infrastructure or code.
