### PR TITLE
Ignore `octane:status` vendor command by default

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -185,6 +185,7 @@ trait CapturesState
             'model:prune',
             'nightwatch:agent',
             'nightwatch:status',
+            'octane:status',
             'queue:monitor',
             'reverb:start',
             'schedule:list',

--- a/tests/Unit/CliSamplingTest.php
+++ b/tests/Unit/CliSamplingTest.php
@@ -261,6 +261,7 @@ class CliSamplingTest extends TestCase
         yield ['model:prune'];
         yield ['nightwatch:agent'];
         yield ['nightwatch:status'];
+        yield ['octane:status'];
         yield ['queue:monitor'];
         yield ['reverb:start'];
         yield ['schedule:list'];


### PR DESCRIPTION
fixes #351