### PR TITLE
Standardise naming conventions

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -685,7 +685,7 @@ trait CapturesState
     /**
      * @internal
      */
-    public function prepareForNextScheduledTask(Event $event): void
+    public function prepareForScheduledTask(Event $event): void
     {
         /*
          * Reset state for the current scheduled task execution.

--- a/src/Hooks/ScheduledTaskListener.php
+++ b/src/Hooks/ScheduledTaskListener.php
@@ -37,7 +37,7 @@ final class ScheduledTaskListener
         }
 
         if ($event instanceof ScheduledTaskSkipped) {
-            $this->nightwatch->prepareForNextScheduledTask($event->task);
+            $this->nightwatch->prepareForScheduledTask($event->task);
         }
 
         try {

--- a/src/Hooks/ScheduledTaskStartingListener.php
+++ b/src/Hooks/ScheduledTaskStartingListener.php
@@ -24,7 +24,7 @@ final class ScheduledTaskStartingListener
     public function __invoke(ScheduledTaskStarting $event): void
     {
         try {
-            $this->nightwatch->prepareForNextScheduledTask($event->task);
+            $this->nightwatch->prepareForScheduledTask($event->task);
         } catch (Throwable $e) {
             $this->nightwatch->report($e, handled: true);
         }


### PR DESCRIPTION
We currently use the following naming conventions:

`prepareForNextThing()` when we don't currently have an instance of `Thing`.
`prepareForThing($thing)` when we do have an instance of `Thing`.