### PR TITLE
Persist git credentials for release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          persist-credentials: true
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch last release tag


### PR DESCRIPTION
Recent changes and upgrades to the actions workflows (#363) have caused the release publishing [workflow to break](https://github.com/laravel/nightwatch/actions/runs/26860670687/job/79214041942).

This workflow needs access to push tags and changelog updates to the repo so needs the token persisted.

Unfortunately, cannot test this until merging and attempting a release. However, going over the recent changes and docs, this seems the [likely culprit](https://github.com/EndBug/add-and-commit#about-actionscheckout). 