### PR TITLE
GitHub Actions hardening

### DIFF
--- a/.github/workflows/facades.yml
+++ b/.github/workflows/facades.yml
@@ -18,7 +18,7 @@ jobs:
     name: Facade DocBlocks
 
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ vars.NIGHTWATCH_PERMISSIONS_APP_ID }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -30,7 +30,7 @@ jobs:
         if: github.ref != 'refs/heads/1.x'
         run: exit 1
 
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: app-token
         with:
           app-id: ${{ vars.NIGHTWATCH_PERMISSIONS_APP_ID }}
@@ -129,7 +129,7 @@ jobs:
           compare-url-target-revision: "1.x"
           parse-github-usernames: true
 
-      - uses: EndBug/add-and-commit@v10
+      - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           default_author: github_actions
           message: "Bump version to v${{ steps.bump-version.outputs.version }}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         if: github.actor != 'dependabot[bot]'
         id: app-token
         with:
@@ -128,7 +128,7 @@ jobs:
 
       - name: Checkout repository
         if: github.actor == 'dependabot[bot]'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup PHP ${{ env.minimum_supported_php_version }} and tooling
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
@@ -160,7 +160,7 @@ jobs:
       - name: Run Pint
         run: vendor/bin/pint
 
-      - uses: EndBug/add-and-commit@v10
+      - uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
         with:
           default_author: github_actions
           message: "Fix code styling"
@@ -182,7 +182,7 @@ jobs:
         working-directory: ./agent
 
     steps:
-      - uses: actions/create-github-app-token@v3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         if: github.actor != 'dependabot[bot]'
         id: app-token
         with:
@@ -199,7 +199,7 @@ jobs:
 
       - name: Checkout repository
         if: github.actor == 'dependabot[bot]'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Build agent
         id: build-agent


### PR DESCRIPTION
We are doing 3 things across the organization:

1. Pinning GitHub Actions to full commit SHAs (instead of mutable tags/branches).
2. Tightening workflow `permissions:` to least-privilege (write scope only where a step needs it).
3. Adding a Dependabot config to keep the pinned actions updated.

This pull request is part of that work.