### PR TITLE
Capture and restore first trace on initial framework boot

### DIFF
--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -134,13 +134,13 @@ final class NightwatchServiceProvider extends ServiceProvider
 
     private static bool $booted = false;
 
-    private static ?string $trace = null;
+    private static ?string $initialTrace = null;
 
     public function register(): void
     {
-        if (self::$trace) {
+        if (self::$initialTrace) {
             // `config:cache` command reboots the framework so we capture the trace on first boot and restore it subsequently
-            Compatibility::addTraceIdToContext(self::$trace);
+            Compatibility::addTraceIdToContext(self::$initialTrace);
 
             return;
         }
@@ -262,7 +262,7 @@ final class NightwatchServiceProvider extends ServiceProvider
         $trace = $this->isRequest && Compatibility::$isLaravelCloud
             ? ($_SERVER['HTTP_CLOUD_REQUEST_ID'] ?? $uuid->make())
             : $uuid->make();
-        self::$trace = $trace;
+        self::$initialTrace = $trace;
         $executionState = $this->executionState($trace);
         $tokenHash = substr(hash('xxh128', $this->nightwatchConfig['token'] ?? ''), 0, 7);
 
@@ -544,12 +544,6 @@ final class NightwatchServiceProvider extends ServiceProvider
         });
     }
 
-    public static function flushState(): void
-    {
-        self::$booted = false;
-        self::$trace = null;
-    }
-
     private function executionState(string $trace): RequestState|CommandState
     {
         Compatibility::addTraceIdToContext($trace);
@@ -595,5 +589,11 @@ final class NightwatchServiceProvider extends ServiceProvider
             fn () => $this->core->userDetailsResolver,
             fn () => $this->core->report(...),
         );
+    }
+
+    public static function flushState(): void
+    {
+        self::$booted = false;
+        self::$initialTrace = null;
     }
 }

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -132,8 +132,19 @@ final class NightwatchServiceProvider extends ServiceProvider
 
     private ?Throwable $registerException = null;
 
+    private static bool $booted = false;
+
+    private static ?string $trace = null;
+
     public function register(): void
     {
+        if (self::$trace) {
+            // `config:cache` command reboots the framework so we capture the trace on first boot and restore it subsequently
+            Compatibility::addTraceIdToContext(self::$trace);
+
+            return;
+        }
+
         try {
             $this->captureTimestamp();
             Compatibility::boot($this->app);
@@ -153,6 +164,12 @@ final class NightwatchServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        if (self::$booted) {
+            return;
+        }
+
+        self::$booted = true;
+
         try {
             if ($this->registerException) {
                 $this->handleAndClearRegisterException();
@@ -245,6 +262,7 @@ final class NightwatchServiceProvider extends ServiceProvider
         $trace = $this->isRequest && Compatibility::$isLaravelCloud
             ? ($_SERVER['HTTP_CLOUD_REQUEST_ID'] ?? $uuid->make())
             : $uuid->make();
+        self::$trace = $trace;
         $executionState = $this->executionState($trace);
         $tokenHash = substr(hash('xxh128', $this->nightwatchConfig['token'] ?? ''), 0, 7);
 
@@ -524,6 +542,12 @@ final class NightwatchServiceProvider extends ServiceProvider
             // Livewire 3
             Livewire::listen('hydrate', $listener->hydrate(...));
         });
+    }
+
+    public static function flushState(): void
+    {
+        self::$booted = false;
+        self::$trace = null;
     }
 
     private function executionState(string $trace): RequestState|CommandState

--- a/tests/Feature/Sensors/LogSensorTest.php
+++ b/tests/Feature/Sensors/LogSensorTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
+use Laravel\Nightwatch\NightwatchServiceProvider;
 use Monolog\LogRecord;
 use RuntimeException;
 use Tests\TestCase;
@@ -274,6 +275,7 @@ class LogSensorTest extends TestCase
     {
         Env::getRepository()->set('LOG_LEVEL', 'warning');
 
+        NightwatchServiceProvider::flushState();
         $this->refreshApplication();
         parent::setUp();
 
@@ -307,6 +309,7 @@ class LogSensorTest extends TestCase
         Env::getRepository()->set('LOG_LEVEL', 'debug');
         Env::getRepository()->set('NIGHTWATCH_LOG_LEVEL', 'warning');
 
+        NightwatchServiceProvider::flushState();
         $this->refreshApplication();
         parent::setUp();
 

--- a/tests/Feature/Sensors/OutgoingRequestSensorTest.php
+++ b/tests/Feature/Sensors/OutgoingRequestSensorTest.php
@@ -6,6 +6,9 @@ use Carbon\CarbonImmutable;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response as Psr7Response;
 use GuzzleHttp\Psr7\StreamDecoratorTrait;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Route;
@@ -88,7 +91,7 @@ class OutgoingRequestSensorTest extends TestCase
         });
         Http::fake([
             'https://laravel.com' => function () {
-                return Http::response(new NoReadStream(null), headers: ['Content-Length' => 5432]);
+                return $this->streamResponse(new NoReadStream(null), ['Content-Length' => 5432]);
             },
         ]);
 
@@ -109,7 +112,7 @@ class OutgoingRequestSensorTest extends TestCase
 
         Http::fake([
             'https://laravel.com' => function ($request) {
-                return Http::response(new NoReadStream(5432));
+                return $this->streamResponse(new NoReadStream(5432));
             },
         ]);
 
@@ -130,7 +133,7 @@ class OutgoingRequestSensorTest extends TestCase
 
         Http::fake([
             'https://laravel.com' => function ($request) {
-                return Http::response(new NoReadStream(null));
+                return $this->streamResponse(new NoReadStream(null));
             },
         ]);
 
@@ -169,7 +172,7 @@ class OutgoingRequestSensorTest extends TestCase
         });
         Http::fake([
             'https://laravel.com' => function () {
-                return Http::response(new NoReadStream(null));
+                return $this->streamResponse(new NoReadStream(null));
             },
         ]);
 
@@ -222,6 +225,11 @@ class OutgoingRequestSensorTest extends TestCase
         $response->assertOk();
         $ingest->assertWrittenTimes(1);
         $ingest->assertLatestWrite('outgoing-request:0.url', 'https://laravel.com');
+    }
+
+    private function streamResponse(StreamInterface $body, array $headers = []): PromiseInterface
+    {
+        return Create::promiseFor(new Psr7Response(200, $headers, $body));
     }
 }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,7 @@ use Laravel\Nightwatch\Core;
 use Laravel\Nightwatch\ExecutionStage;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Ingest;
+use Laravel\Nightwatch\NightwatchServiceProvider;
 use Laravel\Nightwatch\State\CommandState;
 use Laravel\Nightwatch\State\RequestState;
 use Orchestra\Testbench\Concerns\WithWorkbench;
@@ -77,6 +78,8 @@ abstract class TestCase extends OrchestraTestCase
         if (method_exists(WorkCommand::class, 'flushState')) {
             WorkCommand::flushState();
         }
+
+        NightwatchServiceProvider::flushState();
 
         unset($this->core);
 

--- a/tests/Unit/FilteringTest.php
+++ b/tests/Unit/FilteringTest.php
@@ -17,6 +17,7 @@ use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Route;
 use Laravel\Nightwatch\Compatibility;
 use Laravel\Nightwatch\Facades\Nightwatch;
+use Laravel\Nightwatch\NightwatchServiceProvider;
 use Laravel\Nightwatch\Records\CacheEvent;
 use Laravel\Nightwatch\Records\Command;
 use Laravel\Nightwatch\Records\Exception;
@@ -619,6 +620,7 @@ class FilteringTest extends TestCase
     public function test_it_can_redact_commands(): void
     {
         $this->forceCommandExecutionState();
+        NightwatchServiceProvider::flushState();
         $this->refreshApplication();
         parent::setUp();
         $this->app[ConsoleKernel::class]->rerouteSymfonyCommandEvents();


### PR DESCRIPTION
This handles the problem when trace linking is lost when the framework gets booted in-process more than once, as is the case with the `php artisan optimize` command.

We capture the first trace generated on boot and restore that on subsequent boots so all events are properly attributed.
