### PR TITLE
Respect `ExceptionHandler::dontReport` rules when NW manually reports exceptions in hooks

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -263,7 +263,13 @@ trait CapturesState
                     $this->ingest->writeNow($this->sensor->fatalError($e));
                 }
             } else {
-                [$record, $resolver] = $this->sensor->exception($e, $handled);
+                $exception = $this->sensor->exception($e, $handled);
+
+                if ($exception === null) {
+                    return;
+                }
+
+                [$record, $resolver] = $exception;
 
                 foreach ($this->redactExceptionCallbacks as $callback) {
                     $this->ignore(static fn () => ($callback)($record));

--- a/src/Hooks/ContextDehydratingHandler.php
+++ b/src/Hooks/ContextDehydratingHandler.php
@@ -29,7 +29,7 @@ final class ContextDehydratingHandler
                 $context->addHidden('nightwatch_user_id', $this->nightwatch->executionState->user->resolvedUserId());
             }
         } catch (Throwable $e) {
-            $this->nightwatch->report($e);
+            $this->nightwatch->report($e, handled: true);
         }
     }
 }

--- a/src/Hooks/CreateQueuePayloadHandler.php
+++ b/src/Hooks/CreateQueuePayloadHandler.php
@@ -36,7 +36,7 @@ final class CreateQueuePayloadHandler
                 ],
             ];
         } catch (Throwable $e) {
-            $this->nightwatch->report($e);
+            $this->nightwatch->report($e, handled: true);
 
             return $payload;
         }

--- a/src/Hooks/HttpKernelResolvedHandler.php
+++ b/src/Hooks/HttpKernelResolvedHandler.php
@@ -55,7 +55,7 @@ final class HttpKernelResolvedHandler
         try {
             $kernel->prependToMiddlewarePriority(Sample::class);
         } catch (Throwable $e) {
-            $this->nightwatch->report($e);
+            $this->nightwatch->report($e, handled: true);
         }
     }
 }

--- a/src/Hooks/OctaneListener.php
+++ b/src/Hooks/OctaneListener.php
@@ -26,7 +26,7 @@ final class OctaneListener
         try {
             $this->nightwatch->prepareForRequest($event->request); // @phpstan-ignore class.notFound
         } catch (Throwable $e) {
-            $this->nightwatch->report($e);
+            $this->nightwatch->report($e, handled: true);
         }
     }
 }

--- a/src/Hooks/PolyfillContextDehydration.php
+++ b/src/Hooks/PolyfillContextDehydration.php
@@ -45,7 +45,7 @@ final class PolyfillContextDehydration
                 ],
             ];
         } catch (Throwable $e) {
-            $this->nightwatch->report($e);
+            $this->nightwatch->report($e, handled: true);
 
             return $payload;
         }

--- a/src/Hooks/PolyfillContextHydration.php
+++ b/src/Hooks/PolyfillContextHydration.php
@@ -34,7 +34,7 @@ final class PolyfillContextHydration
                 'nightwatch_user_id' => $nightwatch['nightwatch_user_id'] ?? '',
             ];
         } catch (Throwable $e) {
-            $this->nightwatch->report($e);
+            $this->nightwatch->report($e, handled: true);
 
             Compatibility::$context = [];
         }

--- a/src/Hooks/ScheduledTaskListener.php
+++ b/src/Hooks/ScheduledTaskListener.php
@@ -29,7 +29,7 @@ final class ScheduledTaskListener
         // We report the exception here because the scheduler handles it after the task has finished and the data is ingested.
         // This ensures that the exception is captured in the scheduled task record.
         if ($event instanceof ScheduledTaskFailed) {
-            $this->nightwatch->report($event->exception);
+            $this->nightwatch->report($event->exception, handled: false);
         }
 
         if ($this->isFinishedEventForFailedTask($event)) {

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -272,7 +272,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                 captureRequestPayload: (bool) ($this->nightwatchConfig['capture_request_payload'] ?? false),
                 redactPayloadFields: $this->nightwatchConfig['redact_payload_fields'] ?? ['_token', 'password', 'password_confirmation'],
                 redactHeaders: $this->nightwatchConfig['redact_headers'] ?? ['Authorization', 'Cookie', 'Proxy-Authorization', 'X-XSRF-TOKEN'],
-                config: $this->config,
+                container: $this->app,
             ),
             executionState: $executionState,
             clock: $clock,

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -66,7 +66,7 @@ final class SensorManager
     public $cacheEventSensor;
 
     /**
-     * @var (callable(Throwable, null|bool): array{0: Exception, 1: callable(): array<mixed>})|null
+     * @var (callable(Throwable, null|bool): ?array{0: Exception, 1: callable(): array<mixed>})|null
      */
     public $exceptionSensor;
 

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -6,7 +6,8 @@ use Illuminate\Cache\Events\CacheEvent;
 use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskSkipped;
-use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Config\Repository as Config;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Events\MessageSending;
@@ -140,7 +141,7 @@ final class SensorManager
         private bool $captureRequestPayload,
         private array $redactPayloadFields,
         private array $redactHeaders,
-        private Repository $config,
+        private Container $container,
     ) {
         //
     }
@@ -315,7 +316,7 @@ final class SensorManager
         $sensor = $this->queuedJobSensor ??= new QueuedJobSensor(
             executionState: $this->executionState,
             clock: $this->clock,
-            connectionConfig: $this->config->get('queue.connections') ?? [], // @phpstan-ignore argument.type
+            connectionConfig: $this->container->make(Config::class)->get('queue.connections') ?? [], // @phpstan-ignore argument.type
         );
 
         return $sensor($event);
@@ -329,7 +330,7 @@ final class SensorManager
         $sensor = $this->jobAttemptSensor ??= new JobAttemptSensor(
             commandState: $this->executionState, // @phpstan-ignore argument.type
             clock: $this->clock,
-            connectionConfig: $this->config->get('queue.connections') ?? [], // @phpstan-ignore argument.type
+            connectionConfig: $this->container->make(Config::class)->get('queue.connections') ?? [], // @phpstan-ignore argument.type
         );
 
         return $sensor($event);

--- a/src/SensorManager.php
+++ b/src/SensorManager.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Console\Events\ScheduledTaskSkipped;
 use Illuminate\Contracts\Config\Repository as Config;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
 use Illuminate\Mail\Events\MessageSending;
@@ -250,15 +251,16 @@ final class SensorManager
     }
 
     /**
-     * @return array{0: Exception, 1: callable(): array<mixed>}
+     * @return ?array{0: Exception, 1: callable(): array<mixed>}
      */
-    public function exception(Throwable $e, ?bool $handled): array
+    public function exception(Throwable $e, ?bool $handled): ?array
     {
         $sensor = $this->exceptionSensor ??= new ExceptionSensor(
             executionState: $this->executionState,
             clock: $this->clock,
             location: $this->location,
             captureSourceCode: $this->captureExceptionSourceCode,
+            exceptionHandler: $this->container->make(ExceptionHandler::class),
         );
 
         return $sensor($e, $handled);

--- a/src/Sensors/ExceptionSensor.php
+++ b/src/Sensors/ExceptionSensor.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nightwatch\Sensors;
 
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\View\ViewException;
 use Laravel\Nightwatch\Clock;
@@ -48,15 +49,20 @@ final class ExceptionSensor
         private Clock $clock,
         private Location $location,
         private bool $captureSourceCode,
+        private ExceptionHandler $exceptionHandler,
     ) {
         //
     }
 
     /**
-     * @return array{0: Exception, 1: callable(): array<mixed>}
+     * @return ?array{0: Exception, 1: callable(): array<mixed>}
      */
-    public function __invoke(Throwable $e, ?bool $handled): array
+    public function __invoke(Throwable $e, ?bool $handled): ?array
     {
+        if ($handled !== null && ! $this->exceptionHandler->shouldReport($e)) {
+            return null;
+        }
+
         $nowMicrotime = $this->clock->microtime();
         [$file, $line] = $this->location->forException($e);
         $normalizedException = match ($e->getPrevious()) {

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -181,7 +181,7 @@ final class UserProvider
 
         $report = call_user_func($this->reportResolver);
 
-        $report($e, true);
+        $report($e, handled: true);
     }
 
     /**

--- a/src/UserProvider.php
+++ b/src/UserProvider.php
@@ -181,7 +181,7 @@ final class UserProvider
 
         $report = call_user_func($this->reportResolver);
 
-        $report($e, handled: true);
+        $report($e, handled: true); // @phpstan-ignore argument.unknown
     }
 
     /**

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laravel\Nightwatch\Facades\Nightwatch;
@@ -1002,7 +1003,33 @@ class ExceptionSensorTest extends TestCase
         $ingest->assertLatestWrite('exception:0.code', $longString);
     }
 
-    public function test_reporting_exceptions_directly_to_core_still_respects_ignore_rules(): void
+    public function test_manually_reporting_exceptions_respects_ignore_rules(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        report(new MyException('Whoops 1!'));
+        $this->core->report(new MyException('Whoops 2!'), handled: true);
+        $this->core->report(new MyException('Whoops 3!'), handled: false);
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWriteRecordCount(3);
+        $ingest->assertLatestWrite('exception:0.message', 'Whoops 1!');
+        $ingest->assertLatestWrite('exception:1.message', 'Whoops 2!');
+        $ingest->assertLatestWrite('exception:2.message', 'Whoops 3!');
+
+        $ingest->forgetWrites();
+
+        Exceptions::dontReport(MyException::class);
+        report(new MyException('Whoops 1!'));
+        $this->core->report(new MyException('Whoops 2!'), handled: true);
+        $this->core->report(new MyException('Whoops 3!'), handled: false);
+        $ingest->digest();
+
+        $ingest->assertWrittenTimes(0);
+    }
+
+    public function test_suspicious_operation_exceptions_is_ignored_when_thrown_in_hooks(): void
     {
         $ingest = $this->fakeIngest();
         Route::get('/users', function (): void {

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -1001,6 +1001,21 @@ class ExceptionSensorTest extends TestCase
         $ingest->assertLatestWrite('exception:0.file', $longString);
         $ingest->assertLatestWrite('exception:0.code', $longString);
     }
+
+    public function test_reporting_exceptions_directly_to_core_still_respects_ignore_rules(): void
+    {
+        $ingest = $this->fakeIngest();
+        Route::get('/users', function (): void {
+            //
+        });
+
+        $this->post('/users', ['_method' => '__construct'])
+            ->assertStatus(405);
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWriteRecordCount(1);
+        $ingest->assertLatestWrite('request:0.exceptions', 0);
+    }
 }
 
 final class MyException extends RuntimeException

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -1020,7 +1020,7 @@ class ExceptionSensorTest extends TestCase
 
         $ingest->forgetWrites();
 
-        $this->app[ExceptionHandler::class]->dontReport(MyException::class);
+        $this->app[ExceptionHandler::class]->ignore(MyException::class);
         report(new MyException('Whoops 1!'));
         $this->core->report(new MyException('Whoops 2!'), handled: true);
         $this->core->report(new MyException('Whoops 3!'), handled: false);

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -4,13 +4,13 @@ namespace Tests\Feature\Sensors;
 
 use Carbon\CarbonImmutable;
 use Exception;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Request;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Exceptions;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Laravel\Nightwatch\Facades\Nightwatch;
@@ -1020,7 +1020,7 @@ class ExceptionSensorTest extends TestCase
 
         $ingest->forgetWrites();
 
-        Exceptions::dontReport(MyException::class);
+        $this->app[ExceptionHandler::class]->dontReport(MyException::class);
         report(new MyException('Whoops 1!'));
         $this->core->report(new MyException('Whoops 2!'), handled: true);
         $this->core->report(new MyException('Whoops 3!'), handled: false);


### PR DESCRIPTION
closes #403

When Nightwatch manually reports exception in hooks, we don't check whether the exception should actually be reported or not, as it does not go through the framework's `report` method.

This PR ensures all NW reported methods respect the registered `dontReport` rules.