### PR TITLE
Ingest unhandled exception immediately while sampling

### DIFF
--- a/src/Concerns/CapturesState.php
+++ b/src/Concerns/CapturesState.php
@@ -259,6 +259,8 @@ trait CapturesState
 
         try {
             if ($e instanceof FatalError) {
+                $this->ingest->flush();
+
                 if ($this->sampling) {
                     $this->ingest->writeNow($this->sensor->fatalError($e));
                 }
@@ -275,7 +277,11 @@ trait CapturesState
                     $this->ignore(static fn () => ($callback)($record));
                 }
 
-                $this->ingest->write($resolver());
+                if ($this->sampling && ! $record->handled) {
+                    $this->ingest->writeNow($resolver());
+                } else {
+                    $this->ingest->write($resolver());
+                }
             }
         } catch (Throwable $e) {
             Nightwatch::unrecoverableExceptionOccurred($e);

--- a/tests/FakeIngest.php
+++ b/tests/FakeIngest.php
@@ -170,4 +170,11 @@ class FakeIngest implements IngestContract
     {
         dd($this->decodedWrites()->all());
     }
+
+    public function dump(): self
+    {
+        dump($this->decodedWrites()->all());
+
+        return $this;
+    }
 }

--- a/tests/FakeIngest.php
+++ b/tests/FakeIngest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Assert;
 
 use function collect;
 use function dd;
+use function dump;
 use function explode;
 use function is_array;
 use function json_decode;

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -565,9 +565,6 @@ class ExceptionSensorTest extends TestCase
                 //
             ],
             [
-                'args' => 5,
-            ],
-            [
                 'args' => [],
             ],
             [
@@ -593,7 +590,7 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -397,9 +397,6 @@ class ExceptionSensorTest extends TestCase
                 //
             ],
             [
-                'file' => 5,
-            ],
-            [
                 'file' => 'the/file.php',
             ],
         ]);
@@ -410,7 +407,7 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
@@ -419,11 +416,6 @@ class ExceptionSensorTest extends TestCase
             ],
             [
                 'file' => '[internal function]',
-                'source' => '()',
-                'code' => null,
-            ],
-            [
-                'file' => '[unknown file]',
                 'source' => '()',
                 'code' => null,
             ],

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -485,9 +485,6 @@ class ExceptionSensorTest extends TestCase
                 //
             ],
             [
-                'class' => 5,
-            ],
-            [
                 'class' => 'TheClass',
             ],
         ]);
@@ -498,16 +495,11 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
-                'code' => null,
-            ],
-            [
-                'file' => '[internal function]',
-                'source' => '()',
                 'code' => null,
             ],
             [

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -100,8 +100,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:*', [
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:*', [
             [
                 'v' => 3,
                 't' => 'exception',
@@ -156,9 +156,9 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0._group', hash('xxh128', "Tests\Feature\Sensors\MyException,999,tests/Feature/Sensors/ExceptionSensorTest.php,{$line}"));
-        $ingest->assertLatestWrite('exception:0.code', '999');
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0._group', hash('xxh128', "Tests\Feature\Sensors\MyException,999,tests/Feature/Sensors/ExceptionSensorTest.php,{$line}"));
+        $ingest->assertWrite(0, 'exception:0.code', '999');
     }
 
     public function test_it_can_ingest_reported_exceptions(): void
@@ -234,7 +234,7 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.exceptions', 3);
     }
 
@@ -286,13 +286,13 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('exception');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.line', 0);
-        $ingest->assertLatestWrite('exception:0.file', 'workbench/resources/views/exception.blade.php');
-        $ingest->assertLatestWrite('exception:0.class', 'Exception');
-        $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
-        $ingest->assertLatestWrite('exception:0.code', '999');
-        $ingest->assertLatestWrite('exception:0._group', hash('xxh128', 'Exception,999,workbench/resources/views/exception.blade.php,'));
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.line', 0);
+        $ingest->assertWrite(0, 'exception:0.file', 'workbench/resources/views/exception.blade.php');
+        $ingest->assertWrite(0, 'exception:0.class', 'Exception');
+        $ingest->assertWrite(0, 'exception:0.message', 'Whoops!');
+        $ingest->assertWrite(0, 'exception:0.code', '999');
+        $ingest->assertWrite(0, 'exception:0._group', hash('xxh128', 'Exception,999,workbench/resources/views/exception.blade.php,'));
     }
 
     public function test_it_handles_spatie_view_exceptions(): void
@@ -306,13 +306,13 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('exception');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.line', 6);
-        $ingest->assertLatestWrite('exception:0.file', 'workbench/resources/views/exception.blade.php');
-        $ingest->assertLatestWrite('exception:0.class', 'Exception');
-        $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
-        $ingest->assertLatestWrite('exception:0.code', '999');
-        $ingest->assertLatestWrite('exception:0._group', hash('xxh128', 'Exception,999,workbench/resources/views/exception.blade.php,6'));
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.line', 6);
+        $ingest->assertWrite(0, 'exception:0.file', 'workbench/resources/views/exception.blade.php');
+        $ingest->assertWrite(0, 'exception:0.class', 'Exception');
+        $ingest->assertWrite(0, 'exception:0.message', 'Whoops!');
+        $ingest->assertWrite(0, 'exception:0.code', '999');
+        $ingest->assertWrite(0, 'exception:0._group', hash('xxh128', 'Exception,999,workbench/resources/views/exception.blade.php,6'));
     }
 
     public function test_it_skips_internal_frames_on_php_errors(): void
@@ -327,12 +327,12 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.message', 'Undefined array key 0');
-        $ingest->assertLatestWrite('exception:0.class', 'ErrorException');
-        $ingest->assertLatestWrite('exception:0.file', 'tests/Feature/Sensors/ExceptionSensorTest.php');
-        $ingest->assertLatestWrite('exception:0.line', $line);
-        $ingest->assertLatestWrite('exception:0.trace', function ($trace) use ($line) {
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.message', 'Undefined array key 0');
+        $ingest->assertWrite(0, 'exception:0.class', 'ErrorException');
+        $ingest->assertWrite(0, 'exception:0.file', 'tests/Feature/Sensors/ExceptionSensorTest.php');
+        $ingest->assertWrite(0, 'exception:0.line', $line);
+        $ingest->assertWrite(0, 'exception:0.trace', function ($trace) use ($line) {
             $trace = json_decode($trace, associative: true);
 
             $this->assertSame('tests/Feature/Sensors/ExceptionSensorTest.php:'.$line, $trace[0]['file']);
@@ -364,9 +364,9 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.file', 'app/Models/User.php');
-        $ingest->assertLatestWrite('exception:0.line', 0);
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.file', 'app/Models/User.php');
+        $ingest->assertWrite(0, 'exception:0.line', 0);
     }
 
     public function test_it_captures_handled_and_unhandled_exceptions(): void
@@ -382,9 +382,9 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.handled', true);
-        $ingest->assertLatestWrite('exception:1.handled', false);
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.handled', false);
+        $ingest->assertWrite(1, 'exception:0.handled', true);
     }
 
     public function test_it_handles_the_file_in_the_trace(): void
@@ -410,8 +410,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', json_encode([
+        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
@@ -458,8 +458,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', json_encode([
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
@@ -506,8 +506,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', json_encode([
+        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
@@ -554,8 +554,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', json_encode([
+        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
@@ -617,8 +617,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', json_encode([
+        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
@@ -672,8 +672,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', json_encode([
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
@@ -699,21 +699,21 @@ class ExceptionSensorTest extends TestCase
         ini_set('zend.exception_ignore_args', '1');
         $response = $this->get('/users');
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         if (version_compare(PHP_VERSION, '8.4', '<')) {
-            $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => ! str_contains($trace, '{closure}(Illuminate\\\\Http\\\\Request)'));
+            $ingest->assertWrite(0, 'exception:0.trace', fn ($trace) => ! str_contains($trace, '{closure}(Illuminate\\\\Http\\\\Request)'));
         } else {
-            $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => ! str_contains($trace, trim(json_encode('{closure:'.static::class.'::'.$function.'():'.$line.'}(Illuminate\\Http\\Request)'), '"')));
+            $ingest->assertWrite(0, 'exception:0.trace', fn ($trace) => ! str_contains($trace, trim(json_encode('{closure:'.static::class.'::'.$function.'():'.$line.'}(Illuminate\\Http\\Request)'), '"')));
         }
 
         ini_set('zend.exception_ignore_args', '0');
         $response = $this->get('/users');
         $response->assertServerError();
-        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrittenTimes(4);
         if (version_compare(PHP_VERSION, '8.4', '<')) {
-            $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => str_contains($trace, '{closure}(Illuminate\\\\Http\\\\Request)'));
+            $ingest->assertWrite(2, 'exception:0.trace', fn ($trace) => str_contains($trace, '{closure}(Illuminate\\\\Http\\\\Request)'));
         } else {
-            $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => str_contains($trace, trim(json_encode('{closure:'.static::class.'::'.$function.'():'.$line.'}(Illuminate\\Http\\Request)'), '"')));
+            $ingest->assertWrite(2, 'exception:0.trace', fn ($trace) => str_contains($trace, trim(json_encode('{closure:'.static::class.'::'.$function.'():'.$line.'}(Illuminate\\Http\\Request)'), '"')));
         }
     }
 
@@ -727,8 +727,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => str_contains($trace, '"file":"vendor/laravel/framework/src/Illuminate/Routing/Route.php:'));
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', fn ($trace) => str_contains($trace, '"file":"vendor/laravel/framework/src/Illuminate/Routing/Route.php:'));
     }
 
     public function test_it_does_not_escape_slashes_in_the_trace(): void
@@ -741,8 +741,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => str_contains($trace, '"file":"vendor/laravel/framework/src/Illuminate/Routing/Route.php:'));
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', fn ($trace) => str_contains($trace, '"file":"vendor/laravel/framework/src/Illuminate/Routing/Route.php:'));
     }
 
     public function test_it_can_manually_report_exceptions(): void
@@ -762,8 +762,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertOk();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:*', [
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:*', [
             [
                 'v' => 3,
                 't' => 'exception',
@@ -816,8 +816,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.code', 'HY000');
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.code', 'HY000');
     }
 
     public function test_it_can_capture_exception_messages_containing_binary(): void
@@ -830,11 +830,11 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
 
         // @see https://github.com/laravel/framework/pull/58218
         // @see https://github.com/laravel/framework/releases/tag/v12.45.0
-        $ingest->assertLatestWrite('exception:0.message', version_compare($this->app->version(), '12.45.0', '>=')
+        $ingest->assertWrite(0, 'exception:0.message', version_compare($this->app->version(), '12.45.0', '>=')
             ? 'SQLSTATE[HY000]: General error: 1 no such table: unknown-table (Connection: sqlite, Database: tests/database.sqlite, SQL: select * from "unknown-table" where "foo" = ��#)'
             : 'SQLSTATE[HY000]: General error: 1 no such table: unknown-table (Connection: sqlite, SQL: select * from "unknown-table" where "foo" = ��#)');
     }
@@ -863,8 +863,8 @@ class ExceptionSensorTest extends TestCase
 
         $response = $this->get('/test-exception');
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', function ($value) {
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', function ($value) {
             $frames = collect(json_decode($value, true));
 
             $this->assertEquals([
@@ -987,8 +987,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', function ($trace) {
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', function ($trace) {
             $trace = collect(json_decode($trace, associative: true));
 
             $this->assertCount(10, $trace->where(fn ($frame) => is_array($frame['code'])));
@@ -1012,13 +1012,13 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.class', 'RuntimeException');
-        $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
-        $ingest->assertLatestWrite('exception:0.code', '999');
-        $ingest->assertLatestWrite('exception:0.file', 'tests/fixtures/non-utf-8-source-code.php');
-        $ingest->assertLatestWrite('exception:0.line', 4);
-        $ingest->assertLatestWrite('exception:0.trace', function ($trace) {
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.class', 'RuntimeException');
+        $ingest->assertWrite(0, 'exception:0.message', 'Whoops!');
+        $ingest->assertWrite(0, 'exception:0.code', '999');
+        $ingest->assertWrite(0, 'exception:0.file', 'tests/fixtures/non-utf-8-source-code.php');
+        $ingest->assertWrite(0, 'exception:0.line', 4);
+        $ingest->assertWrite(0, 'exception:0.trace', function ($trace) {
             $frames = collect(json_decode($trace, associative: true));
 
             $frame = $frames->firstWhere('file', 'tests/fixtures/non-utf-8-source-code.php:4');
@@ -1048,8 +1048,8 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.trace', fn ($trace) => str_contains($trace, 'café'));
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.trace', fn ($trace) => str_contains($trace, 'café'));
     }
 
     public function test_it_limits_group_properties()
@@ -1067,9 +1067,9 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.file', $longString);
-        $ingest->assertLatestWrite('exception:0.code', $longString);
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.file', $longString);
+        $ingest->assertWrite(0, 'exception:0.code', $longString);
     }
 
     public function test_manually_reporting_exceptions_respects_ignore_rules(): void
@@ -1081,11 +1081,11 @@ class ExceptionSensorTest extends TestCase
         $this->core->report(new MyException('Whoops 3!'), handled: false);
         $ingest->digest();
 
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWriteRecordCount(3);
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:0.message', 'Whoops 3!');
+        $ingest->assertLatestWriteRecordCount(2);
         $ingest->assertLatestWrite('exception:0.message', 'Whoops 1!');
         $ingest->assertLatestWrite('exception:1.message', 'Whoops 2!');
-        $ingest->assertLatestWrite('exception:2.message', 'Whoops 3!');
 
         $ingest->forgetWrites();
 

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -525,9 +525,6 @@ class ExceptionSensorTest extends TestCase
                 //
             ],
             [
-                'function' => 5,
-            ],
-            [
                 'function' => 'the_function',
             ],
         ]);
@@ -538,16 +535,11 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertWrite(0, 'exception:0.trace', json_encode([
             [
                 'file' => $this->core->sensor->location->normalizeFile($e->getFile()).':'.$e->getLine(),
                 'source' => '',
-                'code' => null,
-            ],
-            [
-                'file' => '[internal function]',
-                'source' => '()',
                 'code' => null,
             ],
             [

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -609,11 +609,6 @@ class ExceptionSensorTest extends TestCase
             ],
             [
                 'file' => '[internal function]',
-                'source' => '()',
-                'code' => null,
-            ],
-            [
-                'file' => '[internal function]',
                 'source' => '(null, bool, int, float, string, array, stdClass, Tests\Feature\Sensors\MyEnum, Closure, resource, resource (closed))',
                 'code' => null,
             ],

--- a/tests/Feature/Sensors/JobAttemptSensorTest.php
+++ b/tests/Feature/Sensors/JobAttemptSensorTest.php
@@ -193,7 +193,7 @@ class JobAttemptSensorTest extends TestCase
         FailedJob::dispatch();
         Artisan::call($workCommand, [...$workOptions, '--tries' => 2]);
 
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('job-attempt:*', [
             [
                 'v' => 1,
@@ -301,7 +301,7 @@ class JobAttemptSensorTest extends TestCase
         FailedJob::dispatch();
         Artisan::call($workCommand, $workOptions);
 
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('job-attempt:*', [
             [
                 'v' => 1,
@@ -565,11 +565,11 @@ class JobAttemptSensorTest extends TestCase
             Artisan::call($workCommand, $options);
         });
 
-        $ingest->assertWrittenTimes(2);
-        $ingest->assertWrite(0, 'job-attempt:0.attempt', 1);
+        $ingest->assertWrittenTimes(4);
         $ingest->assertWrite(0, 'exception:0.message', 'Job failed');
-        $ingest->assertWrite(1, 'job-attempt:0.attempt', 2);
-        $ingest->assertWrite(1, 'exception:0.message', 'Job failed');
+        $ingest->assertWrite(1, 'job-attempt:0.attempt', 1);
+        $ingest->assertWrite(2, 'exception:0.message', 'Job failed');
+        $ingest->assertWrite(3, 'job-attempt:0.attempt', 2);
     }
 
     #[DataProvider('workCommands')]
@@ -702,9 +702,9 @@ class JobAttemptSensorTest extends TestCase
             Artisan::call($workCommand, $options);
         });
 
-        $ingest->assertWrittenTimes(2);
-        $ingest->assertWrite(0, 'job-attempt:0.exception_preview', 'Job failed');
-        $ingest->assertWrite(1, 'job-attempt:0.exception_preview', '');
+        $ingest->assertWrittenTimes(3);
+        $ingest->assertWrite(1, 'job-attempt:0.exception_preview', 'Job failed');
+        $ingest->assertWrite(2, 'job-attempt:0.exception_preview', '');
     }
 
     #[DataProvider('workCommands')]
@@ -1037,8 +1037,8 @@ class JobAttemptSensorTest extends TestCase
             JSON, flags: JSON_THROW_ON_ERROR), flags: JSON_THROW_ON_ERROR)]);
         Artisan::call('queue:work', $this->workCommands()['queue:work'][1]);
 
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:*', function ($exceptions) {
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(0, 'exception:*', function ($exceptions) {
             $this->assertCount(1, $exceptions);
 
             if (version_compare(Application::VERSION, '13.6.0', '>=')) {

--- a/tests/Feature/Sensors/RequestSensorTest.php
+++ b/tests/Feature/Sensors/RequestSensorTest.php
@@ -391,7 +391,7 @@ class RequestSensorTest extends TestCase
         $response = $this->get('/users');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.exceptions', 2);
         $ingest->assertLatestWrite('request:0.exception_preview', 'Unhandled error');
     }
@@ -1130,7 +1130,7 @@ class RequestSensorTest extends TestCase
             ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', function ($payload) {
             $payload = json_decode($payload, true);
             $this->assertSame([
@@ -1170,7 +1170,7 @@ class RequestSensorTest extends TestCase
         ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', function ($payload) {
             $payload = json_decode($payload, true);
             $this->assertSame([
@@ -1200,7 +1200,7 @@ class RequestSensorTest extends TestCase
         ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', function ($payload) {
             $payload = json_decode($payload, true);
             $this->assertSame([
@@ -1226,7 +1226,7 @@ class RequestSensorTest extends TestCase
         ], options: JSON_PRESERVE_ZERO_FRACTION);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', function ($payload) {
             $payload = json_decode($payload, true);
             $this->assertSame(2.0, $payload['amount']);
@@ -1248,7 +1248,7 @@ class RequestSensorTest extends TestCase
         ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', fn ($payload) => str_contains($payload, '"url":"https://example.com/path"'));
     }
 
@@ -1265,7 +1265,7 @@ class RequestSensorTest extends TestCase
         ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', fn ($payload) => str_contains($payload, 'café'));
     }
 
@@ -1286,7 +1286,7 @@ class RequestSensorTest extends TestCase
             ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', function ($payload) {
             $payload = json_decode($payload, true);
             $this->assertSame([
@@ -1320,7 +1320,7 @@ class RequestSensorTest extends TestCase
             ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', function ($payload) {
             $payload = json_decode($payload, true);
             $this->assertSame([
@@ -1352,7 +1352,7 @@ class RequestSensorTest extends TestCase
             ]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', '{"_nightwatch_error":"NOT_ENABLED"}');
     }
 
@@ -1367,7 +1367,7 @@ class RequestSensorTest extends TestCase
         $response = $this->json('GET', '/register?redirect=1');
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', '');
 
         $ingest->forgetWrites();
@@ -1375,7 +1375,7 @@ class RequestSensorTest extends TestCase
         $response = $this->json('GET', '/register?redirect=1', ['foo' => 'bar']);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', '{"foo":"bar","_nightwatch_files":[]}');
 
         $ingest->forgetWrites();
@@ -1383,7 +1383,7 @@ class RequestSensorTest extends TestCase
         $response = $this->json('GET', '/register?redirect=1', ['foo' => UploadedFile::fake()->create('avatar.jpg', 1, 'image/jpeg')]);
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', '{"_nightwatch_files":{"foo":{"originalName":"avatar.jpg","size":1024,"error":0}}}');
     }
 
@@ -1407,7 +1407,7 @@ class RequestSensorTest extends TestCase
         );
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', '{"_nightwatch_error":"UNSUPPORTED_CONTENT_TYPE"}');
 
         $ingest->forgetWrites();
@@ -1424,7 +1424,7 @@ class RequestSensorTest extends TestCase
         );
 
         $response->assertInternalServerError();
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('request:0.payload', '{"_nightwatch_error":"UNSUPPORTED_CONTENT_TYPE"}');
     }
 

--- a/tests/Feature/Sensors/ScheduledTaskSensorTest.php
+++ b/tests/Feature/Sensors/ScheduledTaskSensorTest.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Foundation\Testing\WithConsoleEvents;
 use Illuminate\Queue\InteractsWithQueue;
@@ -467,8 +468,7 @@ class ScheduledTaskSensorTest extends TestCase
 
         Artisan::call('schedule:run');
 
-        $ingest->dump();
-        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrittenTimes(version_compare(Application::VERSION, '12.18.0 ', '>=') ? 2 : 1);
         $ingest->assertLatestWrite('scheduled-task:0.name', 'php artisan app:fly tokyo');
     }
 
@@ -501,7 +501,7 @@ class ScheduledTaskSensorTest extends TestCase
 
         Artisan::call('schedule:run');
 
-        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrittenTimes(version_compare(Application::VERSION, '12.18.0 ', '>=') ? 2 : 1);
         $ingest->assertLatestWrite('scheduled-task:0.name', 'find ./storage/logs -type f -mtime +7 -delete');
     }
 

--- a/tests/Feature/Sensors/ScheduledTaskSensorTest.php
+++ b/tests/Feature/Sensors/ScheduledTaskSensorTest.php
@@ -26,6 +26,7 @@ use function dirname;
 use function hash;
 use function json_decode;
 use function now;
+use function version_compare;
 
 class ScheduledTaskSensorTest extends TestCase
 {

--- a/tests/Feature/Sensors/ScheduledTaskSensorTest.php
+++ b/tests/Feature/Sensors/ScheduledTaskSensorTest.php
@@ -208,7 +208,7 @@ class ScheduledTaskSensorTest extends TestCase
 
         Artisan::call('schedule:run');
 
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('scheduled-task:*', [
             [
                 'v' => 1,
@@ -245,7 +245,7 @@ class ScheduledTaskSensorTest extends TestCase
                 'context' => Compatibility::$contextExists ? '{}' : '',
             ],
         ]);
-        $ingest->assertLatestWrite('exception:0.message', 'Unhandled error');
+        $ingest->assertWrite(0, 'exception:0.message', 'Unhandled error');
     }
 
     public function test_it_ingests_tasks_run_in_background(): void
@@ -467,7 +467,7 @@ class ScheduledTaskSensorTest extends TestCase
 
         Artisan::call('schedule:run');
 
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('scheduled-task:0.name', 'php artisan app:fly tokyo');
     }
 
@@ -500,7 +500,7 @@ class ScheduledTaskSensorTest extends TestCase
 
         Artisan::call('schedule:run');
 
-        $ingest->assertWrittenTimes(1);
+        $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('scheduled-task:0.name', 'find ./storage/logs -type f -mtime +7 -delete');
     }
 

--- a/tests/Feature/Sensors/ScheduledTaskSensorTest.php
+++ b/tests/Feature/Sensors/ScheduledTaskSensorTest.php
@@ -467,6 +467,7 @@ class ScheduledTaskSensorTest extends TestCase
 
         Artisan::call('schedule:run');
 
+        $ingest->dump();
         $ingest->assertWrittenTimes(2);
         $ingest->assertLatestWrite('scheduled-task:0.name', 'php artisan app:fly tokyo');
     }

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -91,6 +91,143 @@ class CoreTest extends TestCase
         ]);
     }
 
+    public function test_it_flushes_buffered_records_before_reporting_a_fatal_error(): void
+    {
+        $ingest = $this->fakeIngest();
+        $this->core->ingest->write(['t' => 'test', 'foo' => 'bar']);
+
+        $this->core->report(new FatalError('Out of memory', 0, ['file' => __FILE__, 'line' => __LINE__], 0));
+
+        // The buffered record is discarded, not sent alongside the fatal error.
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWriteRecordCount(1);
+        $ingest->assertLatestWrite('exception:0.message', 'Out of memory');
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    public function test_it_discards_buffered_records_when_a_fatal_error_occurs_while_not_sampling(): void
+    {
+        $ingest = $this->fakeIngest();
+        $this->core->config['sampling']['exceptions'] = 0;
+        $this->core->dontSample();
+        $this->core->ingest->write(['t' => 'test', 'foo' => 'bar']);
+
+        $this->core->report(new FatalError('Out of memory', 0, ['file' => __FILE__, 'line' => __LINE__], 0));
+
+        $this->assertFalse($this->core->sampling());
+
+        // Nothing is sent: the fatal error is dropped by sampling, and the
+        // previously buffered record is flushed (discarded) regardless.
+        $ingest->assertWrittenTimes(0);
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    public function test_it_writes_an_unhandled_exception_immediately(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $this->core->report(new RuntimeException('Whoops!'), handled: false);
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('exception:0.handled', false);
+        $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    public function test_it_buffers_a_handled_exception_instead_of_writing_it_immediately(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        $this->core->report(new RuntimeException('Whoops!'), handled: true);
+
+        $ingest->assertWrittenTimes(0);
+        $this->assertCount(1, $this->core->ingest->buffer);
+
+        // The record was buffered, not lost; it goes out with the next digest.
+        $this->core->finishExecution();
+
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('exception:0.handled', true);
+    }
+
+    public function test_it_does_not_flush_other_buffered_records_when_writing_an_unhandled_exception_immediately(): void
+    {
+        $ingest = $this->fakeIngest();
+        $this->core->ingest->write(['t' => 'test', 'foo' => 'bar']);
+
+        $this->core->report(new RuntimeException('Whoops!'), handled: false);
+
+        // The unhandled exception is sent on its own, standalone write.
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWriteRecordCount(1);
+        $ingest->assertLatestWrite('exception:0.handled', false);
+
+        // The earlier record is untouched, still sitting in the buffer.
+        $this->assertCount(1, $this->core->ingest->buffer);
+
+        $this->core->finishExecution();
+
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertLatestWrite('test:0.foo', 'bar');
+    }
+
+    public function test_it_buffers_an_unhandled_exception_instead_of_writing_it_immediately_when_not_sampling(): void
+    {
+        $ingest = $this->fakeIngest();
+        $this->core->config['sampling']['exceptions'] = 0;
+        $this->core->dontSample();
+
+        $this->core->report(new RuntimeException('Whoops!'), handled: false);
+
+        $this->assertFalse($this->core->sampling());
+        $ingest->assertWrittenTimes(0);
+        $this->assertCount(1, $this->core->ingest->buffer);
+
+        // Since the execution isn't sampled, finishing it discards the
+        // buffer instead of digesting it, so the record is never sent.
+        $this->core->finishExecution();
+
+        $ingest->assertWrittenTimes(0);
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    public function test_it_does_not_write_when_the_exception_is_not_reported(): void
+    {
+        $ingest = $this->fakeIngest();
+        $this->core->sensor->exceptionSensor = fn () => null;
+
+        $this->core->report(new RuntimeException('Whoops!'), handled: false);
+
+        $ingest->assertWrittenTimes(0);
+        $this->assertCount(0, $this->core->ingest->buffer);
+    }
+
+    public function test_it_gracefully_handles_exceptions_thrown_while_writing_an_unhandled_exception_immediately(): void
+    {
+        $exceptions = [];
+        Nightwatch::handleUnrecoverableExceptionsUsing(function ($e) use (&$exceptions): void {
+            $exceptions[] = $e;
+        });
+        $this->fakeIngest(fn ($ingest, $streams) => new class($ingest, $streams) extends FakeIngest
+        {
+            public bool $thrownInWriteNow = false;
+
+            public function writeNow(array $record): void
+            {
+                $this->thrownInWriteNow = true;
+
+                throw new RuntimeException('Whoops while writing!');
+            }
+        });
+
+        $this->core->report(new RuntimeException('Original exception'), handled: false);
+
+        $this->assertTrue($this->core->ingest->thrownInWriteNow);
+        $this->assertSame(1, $this->core->executionState->exceptions);
+        $this->assertCount(1, $exceptions);
+        $this->assertSame('Whoops while writing!', $exceptions[0]->getMessage());
+    }
+
     #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]
     #[WithEnv('NIGHTWATCH_DEPLOY', '82f35860d8c7e59fe4d81a3256a2bb34c998acd9')]
     public function test_it_uses_nightwatch_deploy_env_for_deployments_by_default(): void

--- a/tests/Unit/Hooks/GuzzleMiddlewareTest.php
+++ b/tests/Unit/Hooks/GuzzleMiddlewareTest.php
@@ -17,7 +17,7 @@ class GuzzleMiddlewareTest extends TestCase
         $this->core->sensor->exceptionSensor = function ($e) use (&$exceptions): array {
             $exceptions[] = $e;
 
-            return [[], fn () => []];
+            return [(object) ['handled' => true], fn () => []];
         };
         $thrownInMicrotimeResolver = false;
         $this->core->clock->microtimeResolver = function () use (&$thrownInMicrotimeResolver): float {

--- a/tests/Unit/SamplingTest.php
+++ b/tests/Unit/SamplingTest.php
@@ -224,7 +224,7 @@ class SamplingTest extends TestCase
     {
         $ingest = $this->fakeIngest();
         $this->core->config['sampling']['requests'] = 0;
-        $this->core->sensor->exceptionSensor = fn () => [[], fn () => []];
+        $this->core->sensor->exceptionSensor = fn () => [(object) ['handled' => true], fn () => []];
         $exception = new RuntimeException('Whoops!');
         Route::get('/users', fn () => throw $exception);
 


### PR DESCRIPTION
There are times when Laravel's shutdown process is interpreted. For example, if you are streaming a response and an exception is thrown, the terminating hooks are not fired.

This PR improves the situation by always ingesting unhanded exceptions immediately when sampling.

I considered adding a shutdown handler, but that raised further questions and concerns. This felt better to me and probably makes exception capture more reliable in the long run.

It does mean potentially higher load on the agent at times, but I think it is likely worth it.