### PR TITLE
Deeply unwrap view exceptions

### DIFF
--- a/src/Sensors/ExceptionSensor.php
+++ b/src/Sensors/ExceptionSensor.php
@@ -65,14 +65,11 @@ final class ExceptionSensor
 
         $nowMicrotime = $this->clock->microtime();
         [$file, $line] = $this->location->forException($e);
-        $normalizedException = match ($e->getPrevious()) {
-            null => $e,
-            default => match (true) {
-                $e instanceof ViewException,
-                $e instanceof IgnitionViewException => $e->getPrevious(),
-                default => $e,
-            },
-        };
+        $normalizedException = $e;
+
+        while (($normalizedException instanceof ViewException || $normalizedException instanceof IgnitionViewException) && $normalizedException->getPrevious() !== null) {
+            $normalizedException = $normalizedException->getPrevious();
+        }
 
         $handled ??= $this->wasManuallyReported($normalizedException);
 

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Http\Request;
 use Illuminate\Support\Env;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
@@ -44,6 +45,7 @@ use function str_repeat;
 use function tap;
 use function trim;
 use function version_compare;
+use function view;
 
 class ExceptionSensorTest extends TestCase
 {
@@ -313,6 +315,26 @@ class ExceptionSensorTest extends TestCase
         $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
         $ingest->assertLatestWrite('exception:0.code', '999');
         $ingest->assertLatestWrite('exception:0._group', hash('xxh128', 'Exception,999,workbench/resources/views/exception.blade.php,6'));
+    }
+
+    public function test_it_unwraps_deeply_nested_view_exceptions(): void
+    {
+        (fn () => $this->namespace = 'App')->call($this->app);
+        Blade::anonymousComponentPath(__DIR__.'/components', 'tests');
+
+        $ingest = $this->fakeIngest();
+        Route::get('/nested-exception', fn () => view()->file(__DIR__.'/foo.blade.php')->render());
+
+        $response = $this->get('/nested-exception');
+
+        $response->assertServerError();
+        $ingest->assertWrittenTimes(1);
+        $ingest->assertLatestWrite('exception:0.class', 'RuntimeException');
+        $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
+        $ingest->assertLatestWrite('exception:0.handled', true);
+        $ingest->assertLatestWrite('exception:1.class', 'RuntimeException');
+        $ingest->assertLatestWrite('exception:1.message', 'Whoops!');
+        $ingest->assertLatestWrite('exception:1.handled', false);
     }
 
     public function test_it_skips_internal_frames_on_php_errors(): void

--- a/tests/Feature/Sensors/ExceptionSensorTest.php
+++ b/tests/Feature/Sensors/ExceptionSensorTest.php
@@ -328,13 +328,13 @@ class ExceptionSensorTest extends TestCase
         $response = $this->get('/nested-exception');
 
         $response->assertServerError();
-        $ingest->assertWrittenTimes(1);
-        $ingest->assertLatestWrite('exception:0.class', 'RuntimeException');
-        $ingest->assertLatestWrite('exception:0.message', 'Whoops!');
-        $ingest->assertLatestWrite('exception:0.handled', true);
-        $ingest->assertLatestWrite('exception:1.class', 'RuntimeException');
-        $ingest->assertLatestWrite('exception:1.message', 'Whoops!');
-        $ingest->assertLatestWrite('exception:1.handled', false);
+        $ingest->assertWrittenTimes(2);
+        $ingest->assertWrite(1, 'exception:0.class', 'RuntimeException');
+        $ingest->assertWrite(1, 'exception:0.message', 'Whoops!');
+        $ingest->assertWrite(1, 'exception:0.handled', true);
+        $ingest->assertWrite(0, 'exception:0.class', 'RuntimeException');
+        $ingest->assertWrite(0, 'exception:0.message', 'Whoops!');
+        $ingest->assertWrite(0, 'exception:0.handled', false);
     }
 
     public function test_it_skips_internal_frames_on_php_errors(): void

--- a/tests/Feature/Sensors/components/profile.blade.php
+++ b/tests/Feature/Sensors/components/profile.blade.php
@@ -1,0 +1,5 @@
+<h1>Hello world</h1>
+
+@php
+    report(new RuntimeException('Whoops!')); throw new RuntimeException('Whoops!');
+@endphp

--- a/tests/Feature/Sensors/foo.blade.php
+++ b/tests/Feature/Sensors/foo.blade.php
@@ -1,0 +1,3 @@
+<h1>Hello world</h1>
+
+<x-tests::profile></x-tests::profile>


### PR DESCRIPTION
View exceptions may be deeply nested. Currently we assume them to be a single layer deep.

This ensures we completely unwrap them and should ensure exceptions are correctly grouped in Nightwatch.

This bug is currently causing issues for Nightwatch customers.