### PR TITLE
Allow limiting events ingested per app / env based on an event listener

### DIFF
--- a/src/Events/IngestingEvents.php
+++ b/src/Events/IngestingEvents.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Laravel\Nightwatch\Events;
+
+final class IngestingEvents
+{
+    /**
+     * @param  list<array<string, mixed>>  $records
+     */
+    public function __construct(
+        public readonly array $records,
+    ) {
+        //
+    }
+}

--- a/src/Ingest.php
+++ b/src/Ingest.php
@@ -23,6 +23,8 @@ final class Ingest implements IngestContract
 
     private bool $shouldDigestWhenBufferIsFull = true;
 
+    private bool $ingesting = false;
+
     /**
      * @param  (callable(string $address, float $timeout): resource)  $streamFactory
      */
@@ -40,6 +42,10 @@ final class Ingest implements IngestContract
 
     public function write(array $record): void
     {
+        if ($this->ingesting) {
+            return;
+        }
+
         $this->buffer->write($record);
 
         if ($this->shouldDigestWhenBufferIsFull && $this->buffer->full) {
@@ -49,6 +55,10 @@ final class Ingest implements IngestContract
 
     public function writeNow(array $record): void
     {
+        if ($this->ingesting) {
+            return;
+        }
+
         if (! $this->dispatchIngestingEvents([$record])) {
             return;
         }
@@ -79,6 +89,10 @@ final class Ingest implements IngestContract
 
     public function digest(): void
     {
+        if ($this->buffer->count() === 0) {
+            return;
+        }
+
         if (! $this->dispatchIngestingEvents($this->buffer->all())) {
             $this->buffer->flush();
 
@@ -97,15 +111,17 @@ final class Ingest implements IngestContract
             return true;
         }
 
-        return $this->events->until(new IngestingEvents($records)) !== false;
+        $this->ingesting = true;
+
+        try {
+            return $this->events->until(new IngestingEvents($records)) !== false;
+        } finally {
+            $this->ingesting = false;
+        }
     }
 
     private function transmit(Payload $payload): void
     {
-        if ($payload->isEmpty()) {
-            return;
-        }
-
         $stream = $this->createStream();
 
         try {

--- a/src/Ingest.php
+++ b/src/Ingest.php
@@ -3,7 +3,9 @@
 namespace Laravel\Nightwatch;
 
 use Deprecated;
+use Illuminate\Contracts\Events\Dispatcher;
 use Laravel\Nightwatch\Contracts\Ingest as IngestContract;
+use Laravel\Nightwatch\Events\IngestingEvents;
 use RuntimeException;
 
 use function call_user_func;
@@ -31,6 +33,7 @@ final class Ingest implements IngestContract
         public $streamFactory,
         public RecordsBuffer $buffer,
         private string $tokenHash,
+        private Dispatcher $events,
     ) {
         $this->transmitTo = "tcp://{$transmitTo}";
     }
@@ -46,6 +49,10 @@ final class Ingest implements IngestContract
 
     public function writeNow(array $record): void
     {
+        if (! $this->dispatchIngestingEvents([$record])) {
+            return;
+        }
+
         $this->transmit(Payload::json([$record], $this->tokenHash));
     }
 
@@ -72,7 +79,25 @@ final class Ingest implements IngestContract
 
     public function digest(): void
     {
+        if (! $this->dispatchIngestingEvents($this->buffer->all())) {
+            $this->buffer->flush();
+
+            return;
+        }
+
         $this->transmit($this->buffer->pull($this->tokenHash));
+    }
+
+    /**
+     * @param  list<array<mixed>>  $records
+     */
+    private function dispatchIngestingEvents(array $records): bool
+    {
+        if ($records === []) {
+            return true;
+        }
+
+        return $this->events->until(new IngestingEvents($records)) !== false;
     }
 
     private function transmit(Payload $payload): void

--- a/src/NightwatchServiceProvider.php
+++ b/src/NightwatchServiceProvider.php
@@ -260,6 +260,7 @@ final class NightwatchServiceProvider extends ServiceProvider
                     length: $this->nightwatchConfig['ingest']['event_buffer'] ?? 500,
                 ),
                 tokenHash: $tokenHash,
+                events: $this->app->make(Dispatcher::class),
             ),
             sensor: new SensorManager(
                 executionState: $executionState,

--- a/src/RecordsBuffer.php
+++ b/src/RecordsBuffer.php
@@ -43,6 +43,14 @@ final class RecordsBuffer implements Countable
         return count($this->records);
     }
 
+    /**
+     * @return list<array<mixed>>
+     */
+    public function all(): array
+    {
+        return $this->records;
+    }
+
     public function pull(string $tokenHash): Payload
     {
         if ($this->records === []) {

--- a/tests/Unit/ArchitectureTest.php
+++ b/tests/Unit/ArchitectureTest.php
@@ -34,6 +34,7 @@ class ArchitectureTest extends TestCase
         $except = [
             \Laravel\Nightwatch\Console\Sample::class,
             \Laravel\Nightwatch\Core::class,
+            \Laravel\Nightwatch\Events\IngestingEvents::class,
             \Laravel\Nightwatch\Facades\Nightwatch::class,
             \Laravel\Nightwatch\Http\Middleware\Sample::class,
             \Laravel\Nightwatch\QueryConnectionType::class,

--- a/tests/Unit/CoreTest.php
+++ b/tests/Unit/CoreTest.php
@@ -5,7 +5,10 @@ namespace Tests\Unit;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Route;
+use Laravel\Nightwatch\Events\IngestingEvents;
 use Laravel\Nightwatch\ExecutionStage;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Orchestra\Testbench\Attributes\WithEnv;
@@ -42,6 +45,23 @@ class CoreTest extends TestCase
         $this->assertTrue($this->core->ingest->thrownInDigest);
         $this->assertCount(1, $exceptions);
         $this->assertSame('Whoops!', $exceptions[0]->getMessage());
+    }
+
+    public function test_records_captured_while_an_ingesting_events_listener_runs_are_not_included_in_the_batch(): void
+    {
+        $ingest = $this->fakeIngest();
+
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) {
+            Cache::get('triggered-by-listener');
+        });
+
+        Cache::get('original-key');
+        $this->core->finishExecution();
+
+        $records = $ingest->decodedWrites()->last();
+
+        $this->assertCount(1, $records);
+        $this->assertSame('original-key', $records[0]['key']);
     }
 
     #[WithEnv('NIGHTWATCH_FORCE_REQUEST', '1')]

--- a/tests/Unit/IngestTest.php
+++ b/tests/Unit/IngestTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Unit;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
+use Laravel\Nightwatch\Events\IngestingEvents;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Payload;
 use RuntimeException;
@@ -546,6 +548,98 @@ class IngestTest extends TestCase
 
         $this->assertCount(4, $writes);
         $this->assertSame(str_repeat('10012:'.Payload::PAYLOAD_VERSION.':'.$tokenHash.':['.implode(',', array_fill(0, 500, json_encode(FakeRecord::make()))).']', 2), implode('', $writes));
+    }
+
+    public function test_write_now_dispatches_an_event_containing_the_records_before_writing(): void
+    {
+        $events = [];
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) use (&$events) {
+            $events[] = $event;
+        });
+        $record = FakeRecord::make();
+
+        $this->core->ingest->writeNow($record);
+
+        $this->assertCount(1, $events);
+        $this->assertSame([$record], $events[0]->records);
+    }
+
+    public function test_a_listener_can_stop_write_now_from_ingesting_by_returning_false(): void
+    {
+        $count = 0;
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) use (&$count) {
+            $count++;
+
+            if ($count === 3 || $count === 4) {
+                return false;
+            }
+        });
+
+        for ($i = 0; $i < 6; $i++) {
+            $this->core->ingest->writeNow(FakeRecord::make());
+        }
+
+        $this->assertSame(6, $count);
+        $this->assertCount(4, StreamWrapper::type('stream_open'));
+    }
+
+    public function test_digest_dispatches_an_event_containing_the_buffered_records_before_writing(): void
+    {
+        $events = [];
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) use (&$events) {
+            $events[] = $event;
+        });
+        $records = [FakeRecord::make(), FakeRecord::make(), FakeRecord::make()];
+
+        foreach ($records as $record) {
+            $this->core->ingest->write($record);
+        }
+        $this->core->ingest->digest();
+
+        $this->assertCount(1, $events);
+        $this->assertSame($records, $events[0]->records);
+    }
+
+    public function test_digest_does_not_dispatch_an_event_when_the_buffer_is_empty(): void
+    {
+        $events = [];
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) use (&$events) {
+            $events[] = $event;
+        });
+
+        $this->core->ingest->digest();
+
+        $this->assertCount(0, $events);
+    }
+
+    public function test_a_listener_can_stop_digest_from_ingesting_by_returning_false(): void
+    {
+        Event::listen(IngestingEvents::class, fn () => false);
+
+        $this->core->ingest->write(FakeRecord::make());
+        $this->core->ingest->write(FakeRecord::make());
+        $this->core->ingest->digest();
+
+        $this->assertCount(0, StreamWrapper::type('stream_open'));
+        $this->assertSame(0, $this->core->ingest->buffer->count());
+    }
+
+    public function test_write_auto_digesting_after_reaching_the_threshold_dispatches_an_event_and_can_be_stopped(): void
+    {
+        $count = 0;
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) use (&$count) {
+            $count++;
+
+            return false;
+        });
+
+        for ($i = 0; $i < 500; $i++) {
+            $this->core->ingest->write(FakeRecord::make());
+        }
+
+        $this->assertSame(1, $count);
+        $this->assertCount(0, StreamWrapper::type('stream_open'));
+        $this->assertSame(0, $this->core->ingest->buffer->count());
     }
 
     public function test_it_closes_the_stream_if_an_error_occurs_while_writing(): void

--- a/tests/Unit/IngestTest.php
+++ b/tests/Unit/IngestTest.php
@@ -4,6 +4,7 @@ namespace Tests\Unit;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\RateLimiter;
 use Laravel\Nightwatch\Events\IngestingEvents;
 use Laravel\Nightwatch\Facades\Nightwatch;
 use Laravel\Nightwatch\Payload;
@@ -581,6 +582,26 @@ class IngestTest extends TestCase
 
         $this->assertSame(6, $count);
         $this->assertCount(4, StreamWrapper::type('stream_open'));
+    }
+
+    public function test_a_listener_can_stop_ingestion_using_the_rate_limiter(): void
+    {
+        Event::listen(function (IngestingEvents $event) {
+            return ! RateLimiter::attempt(
+                key: 'nightwatch-events-test',
+                maxAttempts: 2,
+                callback: fn () => true,
+                decaySeconds: 3600,
+            );
+        });
+
+        for ($i = 0; $i < 4; $i++) {
+            $this->core->ingest->writeNow(FakeRecord::make());
+        }
+
+        $this->assertCount(2, StreamWrapper::type('stream_open'));
+
+        RateLimiter::clear('nightwatch-events-test');
     }
 
     public function test_digest_dispatches_an_event_containing_the_buffered_records_before_writing(): void

--- a/tests/Unit/IngestTest.php
+++ b/tests/Unit/IngestTest.php
@@ -22,6 +22,7 @@ use function fopen;
 use function implode;
 use function json_encode;
 use function phpversion;
+use function report;
 use function str_repeat;
 use function stream_wrapper_register;
 use function stream_wrapper_unregister;
@@ -582,6 +583,24 @@ class IngestTest extends TestCase
 
         $this->assertSame(6, $count);
         $this->assertCount(4, StreamWrapper::type('stream_open'));
+    }
+
+    public function test_an_exception_thrown_by_a_listener_is_treated_as_unrecoverable_and_ingestion_continues(): void
+    {
+        $exceptions = [];
+        Nightwatch::handleUnrecoverableExceptionsUsing(function ($e) use (&$exceptions): void {
+            $exceptions[] = $e;
+        });
+        Event::listen(IngestingEvents::class, function (IngestingEvents $event) {
+            throw new RuntimeException('Whoops!');
+        });
+
+        report('Original exception');
+        $this->core->finishExecution();
+
+        $this->assertCount(1, $exceptions);
+        $this->assertSame('Whoops!', $exceptions[0]->getMessage());
+        $this->assertCount(0, StreamWrapper::type('stream_open'));
     }
 
     public function test_a_listener_can_stop_ingestion_using_the_rate_limiter(): void


### PR DESCRIPTION
This allows customers to limit the number of events ingested at an environment level, application level, or more. For example, a customer could restrict the ingestion of several apps in a group if they can all talk to a shared cache.

The below example will limit this app to 1_000 events per day.

```php
use Illuminate\Support\Facades\RateLimiter;
use Illuminate\Support\Facades\Event;
use Laravel\Nightwatch\Events\IngestingEvents;

Event::listen(function (IngestingEvents $event) {
    $count = RateLimiter::increment(
        key: 'nightwatch-events',
        decaySeconds: 60 * 60 * 24,
        amount: count($event->records),
    );

    // Only send a max of 1,000 events per day

    if ($count >= 1_000) {
        return false;
    }
});
```

Events occurring during the listener will not be collected by Nightwatch.